### PR TITLE
Fixed issue with initializing S2SRTTComms during runtime.

### DIFF
--- a/BrainCloudS2SPlugin.uplugin
+++ b/BrainCloudS2SPlugin.uplugin
@@ -18,7 +18,16 @@
 		{
 			"Name": "BrainCloudS2SPlugin",
 			"Type": "Runtime",
-			"LoadingPhase": "PreDefault"
+			"LoadingPhase": "PreDefault",
+			"AdditionalDependencies": [
+				"BCClient"
+			]
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "BCClient",
+			"Enabled": true
 		}
 	]
 }

--- a/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
@@ -5,7 +5,7 @@
 #include "S2SSocket.h"
 #include "BrainCloudS2S.h"
 
-//#include "S2SRTTComms.generated.h"
+#include "S2SRTTComms.generated.h"
 
 #define INITIAL_HEARTBEAT_TIME 10
 
@@ -21,11 +21,10 @@ class US2SCommsProxy;
 class US2SSocket;
 
 
-//UCLASS(MinimalAPI)
+UCLASS(Blueprintable, BlueprintType)
 class BRAINCLOUDS2SPLUGIN_API US2SRTTComms : public UObject
 {
-	//GENERATED_BODY()
-
+	GENERATED_BODY()
 public:
 	US2SRTTComms();
 	~US2SRTTComms();


### PR DESCRIPTION
There was an issue with initializing the S2SRTTComms class when using this library as a submodule, this is now fixed. Also added the BCClient plugin as a dependency to this plugin.