### PR TITLE
Fix for enabling RTT

### DIFF
--- a/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
@@ -30,6 +30,8 @@ void US2SRTTComms::InitializeS2S(const FString& appId, const FString& serverName
         serverSecret,
         url, true));
 
+    this->m_appId = appId;
+
     m_s2sClient->Init(appId, serverName, serverSecret, url, true);
 
     // Verbose log
@@ -354,7 +356,7 @@ FString US2SRTTComms::buildConnectionRequest()
     sysJson->SetStringField("protocol", "ws");
 
     TSharedRef<FJsonObject> jsonData = MakeShareable(new FJsonObject());
-    jsonData->SetStringField("appId", getenv("APP_ID"));
+    jsonData->SetStringField("appId", m_appId);
     jsonData->SetStringField("sessionId", m_s2sClient->getSessionID());
     jsonData->SetStringField("profileId", "s");
     jsonData->SetObjectField("system", sysJson);

--- a/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
@@ -143,6 +143,7 @@ private:
 
 	FString m_cxId;
 	FString m_eventServer;
+	FString m_appId;
 
 	TSharedPtr<UBrainCloudS2S> m_s2sClient;
 	TSharedPtr<FJsonObject> m_rttHeaders;


### PR DESCRIPTION
This was depending on an environment variable, but changed to only use the appId provided in the source code.