### PR TITLE
Nick/s2s refactor

### DIFF
--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
@@ -148,6 +148,32 @@ void UBrainCloudS2S::setLogEnabled(bool enabled)
     _logEnabled = enabled;
 }
 
+void UBrainCloudS2S::setLogObfuscationEnabled(bool enabled)
+{
+    _logObfuscationEnabled = enabled;
+}
+
+FString UBrainCloudS2S::RedactSensitiveJson(const FString& Json)
+{
+    // Fields whose values should be replaced with *** in log output
+    static const TArray<FString> SensitiveKeys = { TEXT("serverSecret") };
+
+    FString Result = Json;
+    for (const FString& Key : SensitiveKeys)
+    {
+        const FString SearchFor = TEXT("\"") + Key + TEXT("\":\"");
+        int32 KeyStart = Result.Find(SearchFor, ESearchCase::CaseSensitive);
+        if (KeyStart == INDEX_NONE) continue;
+
+        const int32 ValueStart = KeyStart + SearchFor.Len();
+        const int32 ValueEnd = Result.Find(TEXT("\""), ESearchCase::CaseSensitive, ESearchDir::FromStart, ValueStart);
+        if (ValueEnd == INDEX_NONE) continue;
+
+        Result = Result.Left(ValueStart) + TEXT("***") + Result.Mid(ValueEnd);
+    }
+    return Result;
+}
+
 void UBrainCloudS2S::sendHeartbeat()
 {
     FString jsonHeartbeatString = "{\"service\":\"heartbeat\",\"operation\":\"HEARTBEAT\"}";
@@ -171,7 +197,8 @@ void UBrainCloudS2S::queueRequest(const TSharedPtr<Request>& pRequest)
 
     if (_logEnabled)
     {
-        UE_LOG(LogBrainCloudS2S, Log, TEXT("Sending request:%s\n"), *dataString);
+        const FString LogString = _logObfuscationEnabled ? RedactSensitiveJson(dataString) : dataString;
+        UE_LOG(LogBrainCloudS2S, Log, TEXT("Sending request:%s\n"), *LogString);
     }
 
     pRequest->pHTTPRequest = FHttpModule::Get().CreateRequest();
@@ -481,6 +508,11 @@ US2SCallback UBrainCloudS2S::WrapBPDelegate(const FS2SResponseDelegate& Delegate
 void UBrainCloudS2S::S2S_SetLogEnabled(bool bEnabled)
 {
     setLogEnabled(bEnabled);
+}
+
+void UBrainCloudS2S::S2S_SetLogObfuscationEnabled(bool bEnabled)
+{
+    setLogObfuscationEnabled(bEnabled);
 }
 
 void UBrainCloudS2S::S2S_Request(const FString& JsonString, const FS2SResponseDelegate& Callback)

--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
@@ -187,7 +187,8 @@ void UBrainCloudS2S::queueRequest(const TSharedPtr<Request>& pRequest)
 void UBrainCloudS2S::request(const FString& jsonString, const US2SCallback& callback)
 {
     // If autoAuth is on
-    UE_LOG(LogBrainCloudS2S, Log, TEXT("[S2SRequest] autoAuth: %s \n"), _autoAuth ? TEXT("true") : TEXT("false"));
+    if (_logEnabled)
+        UE_LOG(LogBrainCloudS2S, Log, TEXT("[S2SRequest] autoAuth: %s"), _autoAuth ? TEXT("true") : TEXT("false"));
     if (_autoAuth)
     {
         if (_sessionData.state != S2SState::Authenticated && !_requestQueue.Num())
@@ -286,9 +287,6 @@ void UBrainCloudS2S::runCallbacks()
     }
     else
     {
-        if(_logEnabled)
-            UE_LOG(LogBrainCloudS2S, Log, TEXT("Number of Waiting Requests, %d"), _requestQueue.Num()); //Check num request in queue
-
         //auto pActiveRequest = _requestQueue[0];
         auto pActiveRequest = _activeRequest;
         EHttpRequestStatus::Type status = pActiveRequest->pHTTPRequest->GetStatus();

--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
@@ -2,6 +2,10 @@
 #include "BrainCloudS2S.h"
 #include "S2SGlobalFileV3.h"
 #include "S2SRTTComms.h"
+#include "S2SServiceName.h"
+#include "S2SServiceOperation.h"
+#include "S2SOperationParam.h"
+#include "S2SRequestBuilder.h"
 #include "Logging/LogMacros.h"
 #include "Http.h"
 #include "Json.h"
@@ -101,7 +105,14 @@ void UBrainCloudS2S::authenticate(const US2SCallback& callback)
     if (_sessionData.state != S2SState::Authenticated)
     {
         _sessionData.state = S2SState::Authenticating;
-        FString jsonAuthString = "{\"service\":\"authenticationV2\",\"operation\":\"AUTHENTICATE\",\"data\":{\"appId\":\"" + _sessionData.appId + "\",\"serverName\":\"" + _sessionData.serverName + "\",\"serverSecret\":\"" + _sessionData.serverSecret + "\"}}";
+
+        TSharedRef<FJsonObject> AuthData = MakeShared<FJsonObject>();
+        AuthData->SetStringField(S2SOperationParam::AppId,        _sessionData.appId);
+        AuthData->SetStringField(S2SOperationParam::ServerName,   _sessionData.serverName);
+        AuthData->SetStringField(S2SOperationParam::ServerSecret, _sessionData.serverSecret);
+        const FString jsonAuthString = S2SRequestBuilder::Build(
+            S2SServiceName::AuthenticationV2, S2SServiceOperation::Authenticate, AuthData);
+
         TSharedPtr<Request> pAuthRequest(new Request{
             jsonAuthString,
             callback,
@@ -176,7 +187,8 @@ FString UBrainCloudS2S::RedactSensitiveJson(const FString& Json)
 
 void UBrainCloudS2S::sendHeartbeat()
 {
-    FString jsonHeartbeatString = "{\"service\":\"heartbeat\",\"operation\":\"HEARTBEAT\"}";
+    const FString jsonHeartbeatString = S2SRequestBuilder::Build(
+        S2SServiceName::Heartbeat, S2SServiceOperation::Heartbeat);
     TSharedPtr<Request> pAuthRequest(new Request{
         jsonHeartbeatString,
         std::bind(&UBrainCloudS2S::onHeartbeatCallback, this, std::placeholders::_1),
@@ -256,17 +268,16 @@ void UBrainCloudS2S::onHeartbeatCallback(const FString& jsonString)
 
 void UBrainCloudS2S::CheckAuthCredentials(TSharedPtr<FJsonObject> authResponse)
 {
-    if (authResponse && authResponse->HasField("data"))
+    if (authResponse && authResponse->HasField(TEXT("data")))
     {
-        const auto& pData = authResponse->GetObjectField("data");
-        if (pData->HasField("heartbeatSeconds"))
+        const auto& pData = authResponse->GetObjectField(TEXT("data"));
+        if (pData->HasField(S2SOperationParam::HeartbeatSeconds))
         {
-            _sessionData.heartbeatInterval = pData->GetNumberField("heartbeatSeconds");
-            //_heartbeatInverval = 300;
+            _sessionData.heartbeatInterval = pData->GetNumberField(S2SOperationParam::HeartbeatSeconds);
         }
-        if (pData->HasField("sessionId"))
+        if (pData->HasField(S2SOperationParam::SessionId))
         {
-            _sessionData.sessionId = pData->GetStringField("sessionId");
+            _sessionData.sessionId = pData->GetStringField(S2SOperationParam::SessionId);
         }
         _sessionData.heartbeatStartTime = FPlatformTime::Seconds();
         _sessionData.state = S2SState::Authenticated;
@@ -333,9 +344,9 @@ void UBrainCloudS2S::runCallbacks()
                 TSharedPtr<FJsonObject> jsonMessage;
                 if (FJsonSerializer::Deserialize(reader, jsonPacket))
                 {
-                    if (jsonPacket->HasField("messageResponses"))
+                    if (jsonPacket->HasField(S2SOperationParam::MessageResponses))
                     {
-                        const auto& messages = jsonPacket->GetArrayField("messageResponses");
+                        const auto& messages = jsonPacket->GetArrayField(S2SOperationParam::MessageResponses);
                         if (messages.Num())
                         {
                             jsonMessage = messages[0]->AsObject();
@@ -382,7 +393,7 @@ void UBrainCloudS2S::runCallbacks()
                     // If it's a session expired, we disconnect
                     if (jsonMessage && jsonMessage->HasField("reason_code"))
                     {
-                        if (jsonMessage->GetIntegerField("reason_code") == SERVER_SESSION_EXPIRED)
+                        if (jsonMessage->GetIntegerField(S2SOperationParam::ReasonCode) == SERVER_SESSION_EXPIRED)
                         {
                             // Disconect then redo the request. It will try to re-authenticate
                             UE_LOG(LogBrainCloudS2S, Warning, TEXT("S2S session expired"));

--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
@@ -1,5 +1,7 @@
 // Copyright 2026 bitHeads, Inc. All Rights Reserved.
 #include "BrainCloudS2S.h"
+#include "S2SGlobalFileV3.h"
+#include "S2SRTTComms.h"
 #include "Logging/LogMacros.h"
 #include "Http.h"
 #include "Json.h"
@@ -19,21 +21,6 @@ UBrainCloudS2S::UBrainCloudS2S()
 {
 }
 
-UBrainCloudS2S::UBrainCloudS2S(const FString& appId,
-    const FString& serverName,
-    const FString& serverSecret,
-    const FString& url,
-    bool autoAuth)
-{
-    _sessionData.appId = appId;
-    _sessionData.serverName = serverName;
-    _sessionData.serverSecret = serverSecret;
-    _sessionData.url = url;
-    _sessionData.state = S2SState::Disconnected;
-    _autoAuth = autoAuth;
-    _sessionData.heartbeatInterval = HEARTBEAT_INTERVALE_S;
-}
-
 UBrainCloudS2S::~UBrainCloudS2S()
 {
     for (int32 i = 0; i < _requestQueue.Num(); ++i)
@@ -44,6 +31,22 @@ UBrainCloudS2S::~UBrainCloudS2S()
         }
     }
     _requestQueue.Empty();
+}
+
+// -----------------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------------
+
+UBrainCloudS2S* UBrainCloudS2S::CreateS2SContext(
+    const FString& AppId,
+    const FString& ServerName,
+    const FString& ServerSecret,
+    const FString& Url,
+    bool bAutoAuth)
+{
+    UBrainCloudS2S* Context = NewObject<UBrainCloudS2S>();
+    Context->Init(AppId, ServerName, ServerSecret, Url, bAutoAuth);
+    return Context;
 }
 
 void UBrainCloudS2S::Init(const FString& appId,
@@ -59,6 +62,38 @@ void UBrainCloudS2S::Init(const FString& appId,
     _autoAuth = autoAuth;
     _sessionData.state = S2SState::Disconnected;
     _sessionData.heartbeatInterval = HEARTBEAT_INTERVALE_S;
+
+    InitServices();
+}
+
+void UBrainCloudS2S::InitServices()
+{
+    if (!_globalFileV3)
+    {
+        _globalFileV3 = NewObject<US2SGlobalFileV3>(this);
+    }
+    _globalFileV3->SetS2SContext(this);
+    _globalFileV3->init(_sessionData.url);
+
+    if (!_rttComms)
+    {
+        _rttComms = NewObject<US2SRTTComms>(this);
+    }
+    _rttComms->SetS2SContext(this);
+}
+
+// -----------------------------------------------------------------------
+// Service accessors
+// -----------------------------------------------------------------------
+
+US2SGlobalFileV3* UBrainCloudS2S::GetGlobalFileV3() const
+{
+    return _globalFileV3;
+}
+
+US2SRTTComms* UBrainCloudS2S::GetRTTComms() const
+{
+    return _rttComms;
 }
 
 void UBrainCloudS2S::authenticate(const US2SCallback& callback)
@@ -88,6 +123,14 @@ void UBrainCloudS2S::disconnect()
     _sessionData.packetId = 0;
     _sessionData.sessionId = "";
 
+    if (_globalFileV3)
+    {
+        _globalFileV3->disconnect();
+    }
+    if (_rttComms)
+    {
+        _rttComms->disconnect();
+    }
 }
 
 FString UBrainCloudS2S::getSessionID()
@@ -143,7 +186,7 @@ void UBrainCloudS2S::queueRequest(const TSharedPtr<Request>& pRequest)
 
 void UBrainCloudS2S::request(const FString& jsonString, const US2SCallback& callback)
 {
-    // If autoAuth is on 
+    // If autoAuth is on
     UE_LOG(LogBrainCloudS2S, Log, TEXT("[S2SRequest] autoAuth: %s \n"), _autoAuth ? TEXT("true") : TEXT("false"));
     if (_autoAuth)
     {
@@ -392,4 +435,77 @@ void UBrainCloudS2S::runCallbacks()
             _sessionData.heartbeatStartTime = now;
         }
     }
+
+    // Drive service callbacks
+    if (_globalFileV3)
+    {
+        _globalFileV3->runCallbacks();
+    }
+    if (_rttComms)
+    {
+        _rttComms->runCallbacks();
+    }
+}
+
+// -----------------------------------------------------------------------
+// Blueprint-callable RunCallbacks (uppercase, calls lowercase runCallbacks)
+// -----------------------------------------------------------------------
+
+void UBrainCloudS2S::RunCallbacks()
+{
+    runCallbacks();
+}
+
+// -----------------------------------------------------------------------
+// Blueprint wrapper helper
+// -----------------------------------------------------------------------
+
+US2SCallback UBrainCloudS2S::WrapBPDelegate(const FS2SResponseDelegate& Delegate)
+{
+    FS2SResponseDelegate DelegateCopy = Delegate;
+    return [DelegateCopy](const FString& JsonResponse)
+    {
+        bool bSuccess = false;
+        TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(JsonResponse);
+        TSharedPtr<FJsonObject> JsonObj;
+        if (FJsonSerializer::Deserialize(Reader, JsonObj) && JsonObj->HasField(TEXT("status")))
+        {
+            bSuccess = (JsonObj->GetIntegerField(TEXT("status")) == 200);
+        }
+        DelegateCopy.ExecuteIfBound(bSuccess, JsonResponse);
+    };
+}
+
+// -----------------------------------------------------------------------
+// Blueprint wrappers
+// -----------------------------------------------------------------------
+
+void UBrainCloudS2S::S2S_SetLogEnabled(bool bEnabled)
+{
+    setLogEnabled(bEnabled);
+}
+
+void UBrainCloudS2S::S2S_Request(const FString& JsonString, const FS2SResponseDelegate& Callback)
+{
+    request(JsonString, WrapBPDelegate(Callback));
+}
+
+void UBrainCloudS2S::S2S_Authenticate(const FS2SResponseDelegate& Callback)
+{
+    authenticate(WrapBPDelegate(Callback));
+}
+
+void UBrainCloudS2S::S2S_AuthenticateAuto()
+{
+    authenticate();
+}
+
+void UBrainCloudS2S::S2S_Disconnect()
+{
+    disconnect();
+}
+
+FString UBrainCloudS2S::S2S_GetSessionID() const
+{
+    return _sessionData.sessionId;
 }

--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2S.cpp
@@ -493,11 +493,6 @@ void UBrainCloudS2S::S2S_Authenticate(const FS2SResponseDelegate& Callback)
     authenticate(WrapBPDelegate(Callback));
 }
 
-void UBrainCloudS2S::S2S_AuthenticateAuto()
-{
-    authenticate();
-}
-
 void UBrainCloudS2S::S2S_Disconnect()
 {
     disconnect();

--- a/Source/BrainCloudS2SPlugin/Private/BrainCloudS2SSubsystem.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/BrainCloudS2SSubsystem.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#include "BrainCloudS2SSubsystem.h"
+#include "BrainCloudS2S.h"
+
+void UBrainCloudS2SSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+    Super::Initialize(Collection);
+}
+
+void UBrainCloudS2SSubsystem::Deinitialize()
+{
+    if (S2SContext)
+    {
+        S2SContext->disconnect();
+        S2SContext = nullptr;
+    }
+    Super::Deinitialize();
+}
+
+void UBrainCloudS2SSubsystem::Tick(float DeltaTime)
+{
+    if (S2SContext)
+    {
+        S2SContext->runCallbacks();
+    }
+}
+
+TStatId UBrainCloudS2SSubsystem::GetStatId() const
+{
+    RETURN_QUICK_DECLARE_CYCLE_STAT(UBrainCloudS2SSubsystem, STATGROUP_Tickables);
+}
+
+bool UBrainCloudS2SSubsystem::IsTickable() const
+{
+    return S2SContext != nullptr;
+}
+
+void UBrainCloudS2SSubsystem::InitializeS2S(
+    const FString& AppId,
+    const FString& ServerName,
+    const FString& ServerSecret,
+    const FString& Url,
+    bool bAutoAuth)
+{
+    if (S2SContext)
+    {
+        S2SContext->disconnect();
+    }
+
+    S2SContext = UBrainCloudS2S::CreateS2SContext(AppId, ServerName, ServerSecret, Url, bAutoAuth);
+}
+
+UBrainCloudS2S* UBrainCloudS2SSubsystem::GetS2SContext() const
+{
+    return S2SContext;
+}

--- a/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
@@ -1,29 +1,14 @@
 // Copyright 2026 bitHeads, Inc. All Rights Reserved.
 
-
 #include "S2SGlobalFileV3.h"
 #include "BrainCloudS2S.h"
+#include "S2SServiceName.h"
+#include "S2SServiceOperation.h"
+#include "S2SOperationParam.h"
+#include "S2SRequestBuilder.h"
 #include "Http.h"
 #include "Json.h"
 
-// --------------------------------------------------------------------------
-// Internal helpers
-// --------------------------------------------------------------------------
-
-static FString BuildGFV3Request(const FString& Operation, const TSharedRef<FJsonObject>& Data)
-{
-    TSharedRef<FJsonObject> Request = MakeShared<FJsonObject>();
-    Request->SetStringField(TEXT("service"), TEXT("globalFileV3"));
-    Request->SetStringField(TEXT("operation"), Operation);
-    Request->SetObjectField(TEXT("data"), Data);
-
-    FString Output;
-    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Output);
-    FJsonSerializer::Serialize(Request, Writer);
-
-    // FJsonSerializer does not append a trailing newline, so no stripping needed
-    return Output;
-}
 
 US2SGlobalFileV3::US2SGlobalFileV3() : _generation(0)
 {
@@ -58,7 +43,7 @@ void US2SGlobalFileV3::sysGetFileInfo(const FString& fileId, const US2SCallback&
 {
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("fileId"), fileId);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_FILE_INFO"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysGetFileInfo, Data), callback);
 }
 
 void US2SGlobalFileV3::sysGetFileInfoSimple(const FString& folderPath, const FString& filename,
@@ -67,7 +52,7 @@ void US2SGlobalFileV3::sysGetFileInfoSimple(const FString& folderPath, const FSt
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("folderPath"), folderPath);
     Data->SetStringField(TEXT("filename"), filename);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_FILE_INFO_SIMPLE"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysGetFileInfoSimple, Data), callback);
 }
 
 void US2SGlobalFileV3::sysCheckFilenameExists(const FString& folderPath, const FString& filename,
@@ -76,7 +61,7 @@ void US2SGlobalFileV3::sysCheckFilenameExists(const FString& folderPath, const F
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("folderPath"), folderPath);
     Data->SetStringField(TEXT("filename"), filename);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_CHECK_FILENAME_EXISTS"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysCheckFilenameExists, Data), callback);
 }
 
 void US2SGlobalFileV3::sysCheckFullpathFilenameExists(const FString& fullpathFilename,
@@ -84,14 +69,14 @@ void US2SGlobalFileV3::sysCheckFullpathFilenameExists(const FString& fullpathFil
 {
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("fullPathFilename"), fullpathFilename);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_CHECK_FULLPATH_FILENAME_EXISTS"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysCheckFullpathFilenameExists, Data), callback);
 }
 
 void US2SGlobalFileV3::sysGetGlobalCDNUrl(const FString& fileId, const US2SCallback& callback)
 {
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("fileId"), fileId);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_GLOBAL_CDN_URL"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysGetGlobalCDNUrl, Data), callback);
 }
 
 void US2SGlobalFileV3::sysGetGlobalFileList(const FString& folderPath, bool recurse,
@@ -100,7 +85,7 @@ void US2SGlobalFileV3::sysGetGlobalFileList(const FString& folderPath, bool recu
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("folderPath"), folderPath);
     Data->SetBoolField(TEXT("recurse"), recurse);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_GLOBAL_FILE_LIST"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysGetGlobalFileList, Data), callback);
 }
 
 // --------------------------------------------------------------------------
@@ -119,7 +104,7 @@ void US2SGlobalFileV3::sysMoveToGlobalFile(const FString& userProfileId, const F
     Data->SetStringField(TEXT("globalTreeId"), globalTreeId);
     Data->SetStringField(TEXT("globalFilename"), globalFilename);
     Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_TO_GLOBAL_FILE"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysMoveToGlobalFile, Data), callback);
 }
 
 void US2SGlobalFileV3::sysCopyGlobalFile(const FString& fileId, int version,
@@ -134,7 +119,7 @@ void US2SGlobalFileV3::sysCopyGlobalFile(const FString& fileId, int version,
     Data->SetNumberField(TEXT("treeVersion"), treeVersion);
     Data->SetStringField(TEXT("newFilename"), newFilename);
     Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_COPY_GLOBAL_FILE"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysCopyGlobalFile, Data), callback);
 }
 
 void US2SGlobalFileV3::sysMoveGlobalFile(const FString& fileId, int version,
@@ -149,7 +134,7 @@ void US2SGlobalFileV3::sysMoveGlobalFile(const FString& fileId, int version,
     Data->SetNumberField(TEXT("treeVersion"), treeVersion);
     Data->SetStringField(TEXT("newFilename"), newFilename);
     Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_GLOBAL_FILE"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysMoveGlobalFile, Data), callback);
 }
 
 void US2SGlobalFileV3::sysDeleteGlobalFile(const FString& fileId, int version,
@@ -159,7 +144,7 @@ void US2SGlobalFileV3::sysDeleteGlobalFile(const FString& fileId, int version,
     Data->SetStringField(TEXT("fileId"), fileId);
     Data->SetNumberField(TEXT("version"), version);
     Data->SetStringField(TEXT("filename"), filename);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_GLOBAL_FILE"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysDeleteGlobalFile, Data), callback);
 }
 
 void US2SGlobalFileV3::sysDeleteGlobalFiles(const FString& treeId, const FString& folderPath,
@@ -170,7 +155,7 @@ void US2SGlobalFileV3::sysDeleteGlobalFiles(const FString& treeId, const FString
     Data->SetStringField(TEXT("folderPath"), folderPath);
     Data->SetNumberField(TEXT("treeVersion"), treeVersion);
     Data->SetBoolField(TEXT("recurse"), recurse);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_GLOBAL_FILES"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysDeleteGlobalFiles, Data), callback);
 }
 
 // --------------------------------------------------------------------------
@@ -187,7 +172,7 @@ void US2SGlobalFileV3::sysCreateFolder(const FString& folderPath, int treeVersio
     Data->SetStringField(TEXT("name"), name);
     Data->SetStringField(TEXT("desc"), desc);
     Data->SetBoolField(TEXT("createInterimDirectories"), createInterimDirectories);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_CREATE_FOLDER"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysCreateFolder, Data), callback);
 }
 
 void US2SGlobalFileV3::sysMoveFolder(const FString& treeId, int treeVersion,
@@ -200,7 +185,7 @@ void US2SGlobalFileV3::sysMoveFolder(const FString& treeId, int treeVersion,
     Data->SetStringField(TEXT("newFolderPath"), newFolderPath);
     Data->SetStringField(TEXT("updatedName"), updatedName);
     Data->SetBoolField(TEXT("createInterimDirectories"), createInterimDirectories);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_FOLDER"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysMoveFolder, Data), callback);
 }
 
 void US2SGlobalFileV3::sysRenameFolder(const FString& treeId, int treeVersion,
@@ -210,14 +195,14 @@ void US2SGlobalFileV3::sysRenameFolder(const FString& treeId, int treeVersion,
     Data->SetStringField(TEXT("treeId"), treeId);
     Data->SetNumberField(TEXT("treeVersion"), treeVersion);
     Data->SetStringField(TEXT("updatedName"), updatedName);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_RENAME_FOLDER"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysRenameFolder, Data), callback);
 }
 
 void US2SGlobalFileV3::sysLookupFolder(const FString& fullFolderPath, const US2SCallback& callback)
 {
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
     Data->SetStringField(TEXT("fullFolderPath"), fullFolderPath);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_LOOKUP_FOLDER"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysLookupFolder, Data), callback);
 }
 
 void US2SGlobalFileV3::sysDeleteFolder(const FString& treeId, const FString& folderPath,
@@ -228,7 +213,7 @@ void US2SGlobalFileV3::sysDeleteFolder(const FString& treeId, const FString& fol
     Data->SetStringField(TEXT("folderPath"), folderPath);
     Data->SetNumberField(TEXT("treeVersion"), treeVersion);
     Data->SetBoolField(TEXT("force"), force);
-    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_FOLDER"), Data), callback);
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysDeleteFolder, Data), callback);
 }
 
 // --------------------------------------------------------------------------
@@ -248,7 +233,7 @@ void US2SGlobalFileV3::uploadGlobalFile(const FString& treeId, const FString& fi
 
     int32 gen = _generation.load();
 
-    _s2s->request(BuildGFV3Request(TEXT("SYS_PREPARE_UPLOAD"), Data),
+    _s2s->request(S2SRequestBuilder::Build(S2SServiceName::GlobalFileV3, S2SServiceOperation::SysPrepareUpload, Data),
         [this, gen, filename, fileData, callback](const FString& result)
         {
             if (gen != _generation) return; // stale after disconnect
@@ -259,19 +244,19 @@ void US2SGlobalFileV3::uploadGlobalFile(const FString& treeId, const FString& fi
             if (FJsonSerializer::Deserialize(Reader, JsonMsg) && JsonMsg->HasField(TEXT("data")))
             {
                 TSharedPtr<FJsonObject> JsonData = JsonMsg->GetObjectField(TEXT("data"));
-                if (JsonData->HasField(TEXT("fileDetails")))
+                if (JsonData->HasField(S2SOperationParam::FileDetails))
                 {
-                    TSharedPtr<FJsonObject> Details = JsonData->GetObjectField(TEXT("fileDetails"));
-                    FString UploadId = Details->GetStringField(TEXT("uploadId"));
+                    TSharedPtr<FJsonObject> Details = JsonData->GetObjectField(S2SOperationParam::FileDetails);
+                    FString UploadId = Details->GetStringField(S2SOperationParam::UploadId);
 
                     FString FullUploadUrl = _uploadUrl
                         + TEXT("?gameId=") + _s2s->getSessionData().appId
                         + TEXT("&uploadId=") + UploadId;
 
                     // Use server-supplied uploadUrl if present (mirrors C++ reference behaviour)
-                    if (Details->HasField(TEXT("uploadUrl")))
+                    if (Details->HasField(S2SOperationParam::UploadUrl))
                     {
-                        FString ServerUrl = Details->GetStringField(TEXT("uploadUrl"));
+                        FString ServerUrl = Details->GetStringField(S2SOperationParam::UploadUrl);
                         if (!ServerUrl.IsEmpty())
                         {
                             if (ServerUrl.StartsWith(TEXT("http")))

--- a/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
@@ -83,7 +83,7 @@ void US2SGlobalFileV3::sysCheckFullpathFilenameExists(const FString& fullpathFil
     const US2SCallback& callback)
 {
     TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
-    Data->SetStringField(TEXT("fullpathFilename"), fullpathFilename);
+    Data->SetStringField(TEXT("fullPathFilename"), fullpathFilename);
     _s2s->request(BuildGFV3Request(TEXT("SYS_CHECK_FULLPATH_FILENAME_EXISTS"), Data), callback);
 }
 
@@ -246,7 +246,7 @@ void US2SGlobalFileV3::uploadGlobalFile(const FString& treeId, const FString& fi
     Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
     Data->SetNumberField(TEXT("fileSize"), static_cast<double>(fileData.size()));
 
-    int32 gen = ++_generation;
+    int32 gen = _generation.load();
 
     _s2s->request(BuildGFV3Request(TEXT("SYS_PREPARE_UPLOAD"), Data),
         [this, gen, filename, fileData, callback](const FString& result)
@@ -264,8 +264,33 @@ void US2SGlobalFileV3::uploadGlobalFile(const FString& treeId, const FString& fi
                     TSharedPtr<FJsonObject> Details = JsonData->GetObjectField(TEXT("fileDetails"));
                     FString UploadId = Details->GetStringField(TEXT("uploadId"));
 
-                    FString FullUploadUrl = _uploadUrl + TEXT("?uploadId=") + UploadId
-                        + TEXT("&sessionId=") + _s2s->getSessionID();
+                    FString FullUploadUrl = _uploadUrl
+                        + TEXT("?gameId=") + _s2s->getSessionData().appId
+                        + TEXT("&uploadId=") + UploadId;
+
+                    // Use server-supplied uploadUrl if present (mirrors C++ reference behaviour)
+                    if (Details->HasField(TEXT("uploadUrl")))
+                    {
+                        FString ServerUrl = Details->GetStringField(TEXT("uploadUrl"));
+                        if (!ServerUrl.IsEmpty())
+                        {
+                            if (ServerUrl.StartsWith(TEXT("http")))
+                            {
+                                FullUploadUrl = ServerUrl;
+                            }
+                            else
+                            {
+                                // Relative path — prefix with scheme+host from _uploadUrl
+                                int32 SchemeEnd = _uploadUrl.Find(TEXT("://"));
+                                if (SchemeEnd != INDEX_NONE)
+                                {
+                                    int32 HostEnd = _uploadUrl.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, SchemeEnd + 3);
+                                    if (HostEnd != INDEX_NONE)
+                                        FullUploadUrl = _uploadUrl.Left(HostEnd) + ServerUrl;
+                                }
+                            }
+                        }
+                    }
 
                     sendFileUpload(FullUploadUrl, filename, fileData, callback);
                     return;
@@ -292,7 +317,7 @@ void US2SGlobalFileV3::sendFileUpload(const FString& uploadUrl, const FString& f
     // Build multipart body
     TArray<uint8> Payload;
     {
-        FString Header = FString::Printf(TEXT("--%s\r\nContent-Disposition: form-data; name=\"uploadFile\"; filename=\"%s\"\r\nContent-Type: application/octet-stream\r\n\r\n"), *Boundary, *filename);
+        FString Header = FString::Printf(TEXT("--%s\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%s\"\r\nContent-Type: application/octet-stream\r\n\r\n"), *Boundary, *filename);
         FTCHARToUTF8 HeaderUtf8(*Header);
         Payload.Append(reinterpret_cast<const uint8*>(HeaderUtf8.Get()), HeaderUtf8.Length());
         Payload.Append(fileData.data(), fileData.size());
@@ -314,7 +339,7 @@ void US2SGlobalFileV3::sendFileUpload(const FString& uploadUrl, const FString& f
             }
             else
             {
-                Result = TEXT("{\"status_code\":900,\"message\":\"Upload HTTP request failed\"}");
+                Result = TEXT("{\"status\":900,\"status_message\":\"Upload HTTP request failed\"}");
             }
 
             std::lock_guard<std::mutex> Lock(_uploadMutex);

--- a/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SGlobalFileV3.cpp
@@ -1,0 +1,480 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+
+#include "S2SGlobalFileV3.h"
+#include "BrainCloudS2S.h"
+#include "Http.h"
+#include "Json.h"
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+static FString BuildGFV3Request(const FString& Operation, const TSharedRef<FJsonObject>& Data)
+{
+    TSharedRef<FJsonObject> Request = MakeShared<FJsonObject>();
+    Request->SetStringField(TEXT("service"), TEXT("globalFileV3"));
+    Request->SetStringField(TEXT("operation"), Operation);
+    Request->SetObjectField(TEXT("data"), Data);
+
+    FString Output;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Output);
+    FJsonSerializer::Serialize(Request, Writer);
+
+    // FJsonSerializer does not append a trailing newline, so no stripping needed
+    return Output;
+}
+
+US2SGlobalFileV3::US2SGlobalFileV3() : _generation(0)
+{
+}
+
+void US2SGlobalFileV3::SetS2SContext(UBrainCloudS2S* context)
+{
+    _s2s = context;
+}
+
+void US2SGlobalFileV3::init(const FString& serverUrl)
+{
+    const FString Needle = TEXT("s2sdispatcher");
+    int32 Pos = serverUrl.Find(Needle);
+    if (Pos != INDEX_NONE)
+    {
+        _uploadUrl = serverUrl.Left(Pos)
+            + TEXT("s2suploader/globalfile/upload")
+            + serverUrl.RightChop(Pos + Needle.Len());
+    }
+    else
+    {
+        _uploadUrl = TEXT("https://api.braincloudservers.com/s2suploader/globalfile/upload");
+    }
+}
+
+// --------------------------------------------------------------------------
+// File Info / Query
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::sysGetFileInfo(const FString& fileId, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fileId"), fileId);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_FILE_INFO"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysGetFileInfoSimple(const FString& folderPath, const FString& filename,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetStringField(TEXT("filename"), filename);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_FILE_INFO_SIMPLE"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysCheckFilenameExists(const FString& folderPath, const FString& filename,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetStringField(TEXT("filename"), filename);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_CHECK_FILENAME_EXISTS"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysCheckFullpathFilenameExists(const FString& fullpathFilename,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fullpathFilename"), fullpathFilename);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_CHECK_FULLPATH_FILENAME_EXISTS"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysGetGlobalCDNUrl(const FString& fileId, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fileId"), fileId);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_GLOBAL_CDN_URL"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysGetGlobalFileList(const FString& folderPath, bool recurse,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetBoolField(TEXT("recurse"), recurse);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_GET_GLOBAL_FILE_LIST"), Data), callback);
+}
+
+// --------------------------------------------------------------------------
+// File Management
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::sysMoveToGlobalFile(const FString& userProfileId, const FString& userCloudPath,
+    const FString& userCloudFilename, const FString& globalTreeId,
+    const FString& globalFilename, bool overwriteIfPresent,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("userProfileId"), userProfileId);
+    Data->SetStringField(TEXT("userCloudPath"), userCloudPath);
+    Data->SetStringField(TEXT("userCloudFilename"), userCloudFilename);
+    Data->SetStringField(TEXT("globalTreeId"), globalTreeId);
+    Data->SetStringField(TEXT("globalFilename"), globalFilename);
+    Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_TO_GLOBAL_FILE"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysCopyGlobalFile(const FString& fileId, int version,
+    const FString& newTreeId, int treeVersion,
+    const FString& newFilename, bool overwriteIfPresent,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fileId"), fileId);
+    Data->SetNumberField(TEXT("version"), version);
+    Data->SetStringField(TEXT("newTreeId"), newTreeId);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetStringField(TEXT("newFilename"), newFilename);
+    Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_COPY_GLOBAL_FILE"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysMoveGlobalFile(const FString& fileId, int version,
+    const FString& newTreeId, int treeVersion,
+    const FString& newFilename, bool overwriteIfPresent,
+    const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fileId"), fileId);
+    Data->SetNumberField(TEXT("version"), version);
+    Data->SetStringField(TEXT("newTreeId"), newTreeId);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetStringField(TEXT("newFilename"), newFilename);
+    Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_GLOBAL_FILE"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysDeleteGlobalFile(const FString& fileId, int version,
+    const FString& filename, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fileId"), fileId);
+    Data->SetNumberField(TEXT("version"), version);
+    Data->SetStringField(TEXT("filename"), filename);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_GLOBAL_FILE"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysDeleteGlobalFiles(const FString& treeId, const FString& folderPath,
+    int treeVersion, bool recurse, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("treeId"), treeId);
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetBoolField(TEXT("recurse"), recurse);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_GLOBAL_FILES"), Data), callback);
+}
+
+// --------------------------------------------------------------------------
+// Folder Management
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::sysCreateFolder(const FString& folderPath, int treeVersion,
+    const FString& name, const FString& desc,
+    bool createInterimDirectories, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetStringField(TEXT("name"), name);
+    Data->SetStringField(TEXT("desc"), desc);
+    Data->SetBoolField(TEXT("createInterimDirectories"), createInterimDirectories);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_CREATE_FOLDER"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysMoveFolder(const FString& treeId, int treeVersion,
+    const FString& newFolderPath, const FString& updatedName,
+    bool createInterimDirectories, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("treeId"), treeId);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetStringField(TEXT("newFolderPath"), newFolderPath);
+    Data->SetStringField(TEXT("updatedName"), updatedName);
+    Data->SetBoolField(TEXT("createInterimDirectories"), createInterimDirectories);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_MOVE_FOLDER"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysRenameFolder(const FString& treeId, int treeVersion,
+    const FString& updatedName, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("treeId"), treeId);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetStringField(TEXT("updatedName"), updatedName);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_RENAME_FOLDER"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysLookupFolder(const FString& fullFolderPath, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("fullFolderPath"), fullFolderPath);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_LOOKUP_FOLDER"), Data), callback);
+}
+
+void US2SGlobalFileV3::sysDeleteFolder(const FString& treeId, const FString& folderPath,
+    int treeVersion, bool force, const US2SCallback& callback)
+{
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("treeId"), treeId);
+    Data->SetStringField(TEXT("folderPath"), folderPath);
+    Data->SetNumberField(TEXT("treeVersion"), treeVersion);
+    Data->SetBoolField(TEXT("force"), force);
+    _s2s->request(BuildGFV3Request(TEXT("SYS_DELETE_FOLDER"), Data), callback);
+}
+
+// --------------------------------------------------------------------------
+// Upload
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::uploadGlobalFile(const FString& treeId, const FString& filename,
+    bool overwriteIfPresent, const std::vector<uint8_t>& fileData,
+    const US2SCallback& callback)
+{
+    // Step 1 - send SYS_PREPARE_UPLOAD via S2S dispatcher
+    TSharedRef<FJsonObject> Data = MakeShared<FJsonObject>();
+    Data->SetStringField(TEXT("treeId"), treeId);
+    Data->SetStringField(TEXT("filename"), filename);
+    Data->SetBoolField(TEXT("overwriteIfPresent"), overwriteIfPresent);
+    Data->SetNumberField(TEXT("fileSize"), static_cast<double>(fileData.size()));
+
+    int32 gen = ++_generation;
+
+    _s2s->request(BuildGFV3Request(TEXT("SYS_PREPARE_UPLOAD"), Data),
+        [this, gen, filename, fileData, callback](const FString& result)
+        {
+            if (gen != _generation) return; // stale after disconnect
+
+            // Parse uploadId from result
+            TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(result);
+            TSharedPtr<FJsonObject> JsonMsg = MakeShared<FJsonObject>();
+            if (FJsonSerializer::Deserialize(Reader, JsonMsg) && JsonMsg->HasField(TEXT("data")))
+            {
+                TSharedPtr<FJsonObject> JsonData = JsonMsg->GetObjectField(TEXT("data"));
+                if (JsonData->HasField(TEXT("fileDetails")))
+                {
+                    TSharedPtr<FJsonObject> Details = JsonData->GetObjectField(TEXT("fileDetails"));
+                    FString UploadId = Details->GetStringField(TEXT("uploadId"));
+
+                    FString FullUploadUrl = _uploadUrl + TEXT("?uploadId=") + UploadId
+                        + TEXT("&sessionId=") + _s2s->getSessionID();
+
+                    sendFileUpload(FullUploadUrl, filename, fileData, callback);
+                    return;
+                }
+            }
+
+            // If we get here, the prepare step failed
+            if (callback) callback(result);
+        });
+}
+
+void US2SGlobalFileV3::sendFileUpload(const FString& uploadUrl, const FString& filename,
+    const std::vector<uint8_t>& fileData, const US2SCallback& callback)
+{
+    int32 gen = _generation.load();
+
+    TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
+    HttpRequest->SetURL(uploadUrl);
+    HttpRequest->SetVerb(TEXT("POST"));
+
+    FString Boundary = FGuid::NewGuid().ToString();
+    HttpRequest->SetHeader(TEXT("Content-Type"), FString::Printf(TEXT("multipart/form-data; boundary=%s"), *Boundary));
+
+    // Build multipart body
+    TArray<uint8> Payload;
+    {
+        FString Header = FString::Printf(TEXT("--%s\r\nContent-Disposition: form-data; name=\"uploadFile\"; filename=\"%s\"\r\nContent-Type: application/octet-stream\r\n\r\n"), *Boundary, *filename);
+        FTCHARToUTF8 HeaderUtf8(*Header);
+        Payload.Append(reinterpret_cast<const uint8*>(HeaderUtf8.Get()), HeaderUtf8.Length());
+        Payload.Append(fileData.data(), fileData.size());
+        FString Footer = FString::Printf(TEXT("\r\n--%s--\r\n"), *Boundary);
+        FTCHARToUTF8 FooterUtf8(*Footer);
+        Payload.Append(reinterpret_cast<const uint8*>(FooterUtf8.Get()), FooterUtf8.Length());
+    }
+    HttpRequest->SetContent(Payload);
+
+    HttpRequest->OnProcessRequestComplete().BindLambda(
+        [this, gen, callback](FHttpRequestPtr, FHttpResponsePtr Response, bool bConnectedSuccessfully)
+        {
+            if (gen != _generation.load()) return;
+
+            FString Result;
+            if (bConnectedSuccessfully && Response.IsValid())
+            {
+                Result = Response->GetContentAsString();
+            }
+            else
+            {
+                Result = TEXT("{\"status_code\":900,\"message\":\"Upload HTTP request failed\"}");
+            }
+
+            std::lock_guard<std::mutex> Lock(_uploadMutex);
+            _completedUploads.push({ callback, Result });
+        });
+
+    HttpRequest->ProcessRequest();
+}
+
+// --------------------------------------------------------------------------
+// Lifecycle
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::runCallbacks()
+{
+    std::queue<UploadCompletion> ToDispatch;
+    {
+        std::lock_guard<std::mutex> Lock(_uploadMutex);
+        std::swap(ToDispatch, _completedUploads);
+    }
+
+    while (!ToDispatch.empty())
+    {
+        auto& Item = ToDispatch.front();
+        if (Item.callback) Item.callback(Item.result);
+        ToDispatch.pop();
+    }
+}
+
+void US2SGlobalFileV3::disconnect()
+{
+    ++_generation;
+    std::lock_guard<std::mutex> Lock(_uploadMutex);
+    while (!_completedUploads.empty()) _completedUploads.pop();
+}
+
+void US2SGlobalFileV3::log(const FString& message)
+{
+    UE_LOG(LogBrainCloudS2S, Log, TEXT("[S2SGlobalFileV3] %s"), *message);
+}
+
+// --------------------------------------------------------------------------
+// Blueprint wrapper helper
+// --------------------------------------------------------------------------
+
+US2SCallback US2SGlobalFileV3::WrapBPDelegate(const FS2SResponseDelegate& Delegate)
+{
+    // Copy the delegate so it survives the lambda capture
+    FS2SResponseDelegate DelegateCopy = Delegate;
+    return [DelegateCopy](const FString& JsonResponse)
+    {
+        // Determine success by parsing the status field
+        bool bSuccess = false;
+        TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(JsonResponse);
+        TSharedPtr<FJsonObject> JsonObj;
+        if (FJsonSerializer::Deserialize(Reader, JsonObj) && JsonObj->HasField(TEXT("status")))
+        {
+            bSuccess = (JsonObj->GetIntegerField(TEXT("status")) == 200);
+        }
+        DelegateCopy.ExecuteIfBound(bSuccess, JsonResponse);
+    };
+}
+
+// --------------------------------------------------------------------------
+// Blueprint wrappers
+// --------------------------------------------------------------------------
+
+void US2SGlobalFileV3::S2S_SysGetFileInfo(const FString& FileId, const FS2SResponseDelegate& Callback)
+{
+    sysGetFileInfo(FileId, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysGetFileInfoSimple(const FString& FolderPath, const FString& Filename, const FS2SResponseDelegate& Callback)
+{
+    sysGetFileInfoSimple(FolderPath, Filename, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysCheckFilenameExists(const FString& FolderPath, const FString& Filename, const FS2SResponseDelegate& Callback)
+{
+    sysCheckFilenameExists(FolderPath, Filename, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysCheckFullpathFilenameExists(const FString& FullpathFilename, const FS2SResponseDelegate& Callback)
+{
+    sysCheckFullpathFilenameExists(FullpathFilename, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysGetGlobalCDNUrl(const FString& FileId, const FS2SResponseDelegate& Callback)
+{
+    sysGetGlobalCDNUrl(FileId, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysGetGlobalFileList(const FString& FolderPath, bool bRecurse, const FS2SResponseDelegate& Callback)
+{
+    sysGetGlobalFileList(FolderPath, bRecurse, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysMoveToGlobalFile(const FString& UserProfileId, const FString& UserCloudPath,
+    const FString& UserCloudFilename, const FString& GlobalTreeId,
+    const FString& GlobalFilename, bool bOverwriteIfPresent,
+    const FS2SResponseDelegate& Callback)
+{
+    sysMoveToGlobalFile(UserProfileId, UserCloudPath, UserCloudFilename, GlobalTreeId, GlobalFilename, bOverwriteIfPresent, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysCopyGlobalFile(const FString& FileId, int32 Version,
+    const FString& NewTreeId, int32 TreeVersion,
+    const FString& NewFilename, bool bOverwriteIfPresent,
+    const FS2SResponseDelegate& Callback)
+{
+    sysCopyGlobalFile(FileId, Version, NewTreeId, TreeVersion, NewFilename, bOverwriteIfPresent, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysMoveGlobalFile(const FString& FileId, int32 Version,
+    const FString& NewTreeId, int32 TreeVersion,
+    const FString& NewFilename, bool bOverwriteIfPresent,
+    const FS2SResponseDelegate& Callback)
+{
+    sysMoveGlobalFile(FileId, Version, NewTreeId, TreeVersion, NewFilename, bOverwriteIfPresent, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysDeleteGlobalFile(const FString& FileId, int32 Version,
+    const FString& Filename, const FS2SResponseDelegate& Callback)
+{
+    sysDeleteGlobalFile(FileId, Version, Filename, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysDeleteGlobalFiles(const FString& TreeId, const FString& FolderPath,
+    int32 TreeVersion, bool bRecurse, const FS2SResponseDelegate& Callback)
+{
+    sysDeleteGlobalFiles(TreeId, FolderPath, TreeVersion, bRecurse, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysCreateFolder(const FString& FolderPath, int32 TreeVersion,
+    const FString& Name, const FString& Desc,
+    bool bCreateInterimDirectories, const FS2SResponseDelegate& Callback)
+{
+    sysCreateFolder(FolderPath, TreeVersion, Name, Desc, bCreateInterimDirectories, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysMoveFolder(const FString& TreeId, int32 TreeVersion,
+    const FString& NewFolderPath, const FString& UpdatedName,
+    bool bCreateInterimDirectories, const FS2SResponseDelegate& Callback)
+{
+    sysMoveFolder(TreeId, TreeVersion, NewFolderPath, UpdatedName, bCreateInterimDirectories, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysRenameFolder(const FString& TreeId, int32 TreeVersion,
+    const FString& UpdatedName, const FS2SResponseDelegate& Callback)
+{
+    sysRenameFolder(TreeId, TreeVersion, UpdatedName, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysLookupFolder(const FString& FullFolderPath, const FS2SResponseDelegate& Callback)
+{
+    sysLookupFolder(FullFolderPath, WrapBPDelegate(Callback));
+}
+
+void US2SGlobalFileV3::S2S_SysDeleteFolder(const FString& TreeId, const FString& FolderPath,
+    int32 TreeVersion, bool bForce, const FS2SResponseDelegate& Callback)
+{
+    sysDeleteFolder(TreeId, FolderPath, TreeVersion, bForce, WrapBPDelegate(Callback));
+}

--- a/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
@@ -1,7 +1,9 @@
 // Copyright 2026 bitHeads, Inc. All Rights Reserved.
 
-
 #include "S2SRTTComms.h"
+#include "S2SServiceName.h"
+#include "S2SServiceOperation.h"
+#include "S2SOperationParam.h"
 #include <Kismet/GameplayStatics.h>
 #include "ConvertUtilities.h"
 #include "JsonUtil.h"
@@ -70,8 +72,8 @@ void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& 
 
         TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 
-        JsonObject->SetStringField("service", "rttRegistration");
-        JsonObject->SetStringField("operation", "REQUEST_SYSTEM_CONNECTION");
+        JsonObject->SetStringField(TEXT("service"),   S2SServiceName::RTTRegistration);
+        JsonObject->SetStringField(TEXT("operation"), S2SServiceOperation::RequestSystemConnection);
 
         FString JsonString;
         TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&JsonString);
@@ -91,17 +93,17 @@ void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& 
                 if (res)
                 {
                     TSharedPtr<FJsonObject> jsonData = jsonPacket->GetObjectField(TEXT("data"));
-                    TArray<TSharedPtr<FJsonValue>> endpoints = jsonData->GetArrayField(TEXT("endpoints"));
-                    m_rttHeaders = jsonData->GetObjectField(TEXT("auth"));
+                    TArray<TSharedPtr<FJsonValue>> endpoints = jsonData->GetArrayField(S2SOperationParam::Endpoints);
+                    m_rttHeaders = jsonData->GetObjectField(S2SOperationParam::Auth);
 
                     //setup socket connection
                     TSharedPtr<FJsonObject> endpoint = endpoints[0]->AsObject();
-                    bool sslEnabled = endpoint->GetBoolField(TEXT("ssl"));
+                    bool sslEnabled = endpoint->GetBoolField(S2SOperationParam::Ssl);
 
                     FString url = (sslEnabled ? TEXT("wss://") : TEXT("ws://"));
-                    url += endpoint->GetStringField(TEXT("host"));
-                    url += ":";
-                    url += FString::Printf(TEXT("%d"), endpoint->GetIntegerField(TEXT("port")));
+                    url += endpoint->GetStringField(S2SOperationParam::Host);
+                    url += TEXT(":");
+                    url += FString::Printf(TEXT("%d"), endpoint->GetIntegerField(S2SOperationParam::Port));
                     url += getUrlQueryParameters();
 
                     UE_LOG(S2SWebSocket, Log, TEXT("Setting up web socket with url %s "), *url);
@@ -229,28 +231,29 @@ void US2SRTTComms::webSocket_OnMessage(const TArray<uint8>& in_data)
     UE_LOG(S2SWebSocket, Log, TEXT("RECV: %s "), *parsedMessage);
 
     TSharedPtr<FJsonObject> jsonData = JsonUtil::jsonStringToValue(parsedMessage);
-    FString service = jsonData->HasField(TEXT("service")) ? jsonData->GetStringField(TEXT("service")) : "";
-    FString operation = jsonData->HasField(TEXT("operation")) ? jsonData->GetStringField(TEXT("operation")) : "";
+    FString service   = jsonData->HasField(TEXT("service"))   ? jsonData->GetStringField(TEXT("service"))   : TEXT("");
+    FString operation = jsonData->HasField(TEXT("operation")) ? jsonData->GetStringField(TEXT("operation")) : TEXT("");
     TSharedPtr<FJsonObject> innerData = nullptr;
     bool bIsInnerDataValid = jsonData->HasTypedField<EJson::Object>(TEXT("data"));
 
     if (bIsInnerDataValid)
         innerData = jsonData->GetObjectField(TEXT("data"));
 
-    if (operation == "HEARTBEAT") {
+    if (operation == S2SServiceOperation::Heartbeat)
+    {
         m_heartBeatRecv = true;
     }
 
-    if (operation == "CONNECT")
+    if (operation == S2SServiceOperation::Connect)
     {
         int32 heartBeat = INITIAL_HEARTBEAT_TIME;
-        if (bIsInnerDataValid && innerData->HasField(TEXT("heartbeatSeconds")))
+        if (bIsInnerDataValid && innerData->HasField(S2SOperationParam::HeartbeatSeconds))
         {
-            heartBeat = innerData->GetIntegerField(TEXT("heartbeatSeconds"));
+            heartBeat = innerData->GetIntegerField(S2SOperationParam::HeartbeatSeconds);
         }
-        else if (bIsInnerDataValid && innerData->HasField(TEXT("wsHeartbeatSecs")))
+        else if (bIsInnerDataValid && innerData->HasField(S2SOperationParam::WsHeartbeatSecs))
         {
-            heartBeat = innerData->GetIntegerField(TEXT("wsHeartbeatSecs"));
+            heartBeat = innerData->GetIntegerField(S2SOperationParam::WsHeartbeatSecs);
         }
 
         isRTTEnabled = true;
@@ -258,26 +261,26 @@ void US2SRTTComms::webSocket_OnMessage(const TArray<uint8>& in_data)
 
         rttEnabledSuccessCallback(parsedMessage);
     }
-    else if (operation == "DISCONNECT")
+    else if (operation == S2SServiceOperation::Disconnect)
     {
         m_disconnectedWithReason = true;
-        m_disconnectJson->SetStringField("reason", innerData->GetStringField(TEXT("reason")));
-        m_disconnectJson->SetNumberField("reasonCode", innerData->GetNumberField(TEXT("reasonCode")));
-        m_disconnectJson->SetStringField("severity", "ERROR");
+        m_disconnectJson->SetStringField(S2SOperationParam::Reason,     innerData->GetStringField(S2SOperationParam::Reason));
+        m_disconnectJson->SetNumberField(TEXT("reasonCode"),            innerData->GetNumberField(TEXT("reasonCode")));
+        m_disconnectJson->SetStringField(S2SOperationParam::Severity,   TEXT("ERROR"));
     }
 
     processRTTCallback(parsedMessage);
 
     if (bIsInnerDataValid)
     {
-        if (innerData->HasField(TEXT("cxId")))
+        if (innerData->HasField(S2SOperationParam::CxId))
         {
-            m_cxId = innerData->GetStringField(TEXT("cxId"));
+            m_cxId = innerData->GetStringField(S2SOperationParam::CxId);
         }
 
-        if (innerData->HasField(TEXT("evs")))
+        if (innerData->HasField(S2SOperationParam::Evs))
         {
-            m_eventServer = innerData->GetStringField(TEXT("evs"));
+            m_eventServer = innerData->GetStringField(S2SOperationParam::Evs);
         }
     }
 
@@ -324,20 +327,20 @@ FString US2SRTTComms::buildConnectionRequest()
     FString appId = m_s2sClient ? m_s2sClient->getSessionData().appId : TEXT("");
 
     TSharedRef<FJsonObject> sysJson = MakeShareable(new FJsonObject());
-    sysJson->SetStringField("platform", platform);
-    sysJson->SetStringField("protocol", "ws");
+    sysJson->SetStringField(S2SOperationParam::Platform, platform);
+    sysJson->SetStringField(S2SOperationParam::Protocol, TEXT("ws"));
 
     TSharedRef<FJsonObject> jsonData = MakeShareable(new FJsonObject());
-    jsonData->SetStringField("appId", appId);
-    jsonData->SetStringField("sessionId", m_s2sClient->getSessionID());
-    jsonData->SetStringField("profileId", "s");
-    jsonData->SetObjectField("system", sysJson);
-    jsonData->SetObjectField("auth", m_rttHeaders);
+    jsonData->SetStringField(S2SOperationParam::AppId,     appId);
+    jsonData->SetStringField(S2SOperationParam::SessionId, m_s2sClient->getSessionID());
+    jsonData->SetStringField(S2SOperationParam::ProfileId, TEXT("s"));
+    jsonData->SetObjectField(S2SOperationParam::System,    sysJson);
+    jsonData->SetObjectField(S2SOperationParam::Auth,      m_rttHeaders);
 
     TSharedPtr<FJsonObject> json = MakeShareable(new FJsonObject());
-    json->SetStringField("service", "RTT");
-    json->SetStringField("operation", "CONNECT");
-    json->SetObjectField("data", jsonData);
+    json->SetStringField(TEXT("service"),   S2SServiceName::RTT);
+    json->SetStringField(TEXT("operation"), S2SServiceOperation::Connect);
+    json->SetObjectField(TEXT("data"),      jsonData);
 
     FString JsonString;
     TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&JsonString);
@@ -349,9 +352,9 @@ FString US2SRTTComms::buildConnectionRequest()
 FString US2SRTTComms::buildHeartbeatRequest()
 {
     TSharedRef<FJsonObject> json = MakeShareable(new FJsonObject());
-    json->SetStringField("service", "RTT");
-    json->SetStringField("operation", "HEARTBEAT");
-    json->SetObjectField("data", nullptr);
+    json->SetStringField(TEXT("service"),   S2SServiceName::RTT);
+    json->SetStringField(TEXT("operation"), S2SServiceOperation::Heartbeat);
+    json->SetObjectField(TEXT("data"),      nullptr);
 
     return JsonUtil::jsonValueToString(json);
 }

--- a/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
+++ b/Source/BrainCloudS2SPlugin/Private/S2SRTTComms.cpp
@@ -22,62 +22,51 @@ US2SRTTComms::~US2SRTTComms()
 {
 }
 
-void US2SRTTComms::InitializeS2S(const FString& appId, const FString& serverName, const FString& serverSecret, const FString& url, bool autoAuth, bool logEnabled)
+void US2SRTTComms::SetS2SContext(UBrainCloudS2S* context)
 {
-    // Create S2S context
-    m_s2sClient = MakeShareable(new UBrainCloudS2S(appId,
-        serverName,
-        serverSecret,
-        url, true));
-
-    this->m_appId = appId;
-
-    m_s2sClient->Init(appId, serverName, serverSecret, url, true);
-
-    // Verbose log
-    m_s2sClient->setLogEnabled(logEnabled);
+    m_s2sClient = context;
 }
 
 void US2SRTTComms::runCallbacks()
 {
-    if (m_s2sClient.IsValid()) {
-        m_s2sClient->runCallbacks();
+    // NOTE: S2S HTTP callbacks are driven by UBrainCloudS2S::runCallbacks(),
+    // which calls us. We only handle RTT heartbeat / disconnect logic here.
+    if (m_s2sClient == nullptr) return;
 
-        if (!isRTTEnabled) return;
+    if (!isRTTEnabled) return;
 
-        if (s2sSocket != nullptr) {
-            float nowMS = FPlatformTime::Seconds();
+    if (s2sSocket != nullptr) {
+        float nowMS = FPlatformTime::Seconds();
 
-            m_timeSinceLastRequest += (nowMS - m_lastNowMS);
-            m_lastNowMS = nowMS;
+        m_timeSinceLastRequest += (nowMS - m_lastNowMS);
+        m_lastNowMS = nowMS;
 
-            if (m_heartBeatSent && m_timeSinceLastRequest >= m_heartBeatIdleSecs)
-            {
-                if (!m_heartBeatRecv) {
-                    UE_LOG(LogBrainCloudS2S, Log, TEXT("RTT: lost heartbeat %f idle"), m_heartBeatIdleSecs);
-                    disconnect();
-                }
-                m_heartBeatSent = false;
-            }
-            if (m_timeSinceLastRequest >= m_heartBeatSecs)
-            {
-                m_timeSinceLastRequest = 0;
-                m_heartBeatSent = true;
-                m_heartBeatRecv = false;
-                send(buildHeartbeatRequest(), false);
-            }
-        }
-
-        if (m_disconnectedWithReason)
+        if (m_heartBeatSent && m_timeSinceLastRequest >= m_heartBeatIdleSecs)
         {
-            disconnect();
+            if (!m_heartBeatRecv) {
+                UE_LOG(LogBrainCloudS2S, Log, TEXT("RTT: lost heartbeat %f idle"), m_heartBeatIdleSecs);
+                disconnect();
+            }
+            m_heartBeatSent = false;
         }
+        if (m_timeSinceLastRequest >= m_heartBeatSecs)
+        {
+            m_timeSinceLastRequest = 0;
+            m_heartBeatSent = true;
+            m_heartBeatRecv = false;
+            send(buildHeartbeatRequest(), false);
+        }
+    }
+
+    if (m_disconnectedWithReason)
+    {
+        disconnect();
     }
 }
 
 void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& OnFailure)
 {
-    if (m_s2sClient.IsValid()) {
+    if (m_s2sClient != nullptr) {
 
         TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 
@@ -92,7 +81,7 @@ void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& 
             [this, OnSuccess, OnFailure](const FString& result)
             {
                 UE_LOG(LogBrainCloudS2S, Log, TEXT("Got response for connection request: %s"), *result);
-        
+
 
                 TSharedRef<TJsonReader<TCHAR>> reader = TJsonReaderFactory<TCHAR>::Create(result);
                 TSharedPtr<FJsonObject> jsonPacket = MakeShareable(new FJsonObject());
@@ -120,7 +109,7 @@ void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& 
                     setupWebSocket(url);
                     rttEnabledSuccessCallback = OnSuccess;
                     rttEnabledFailureCallback = OnFailure;
-            
+
                 }
                 else if(status != 200){
                     OnFailure(result);
@@ -131,31 +120,10 @@ void US2SRTTComms::enableRTT(const US2SCallback& OnSuccess, const US2SCallback& 
 
 void US2SRTTComms::disableRTT()
 {
-    if (s2sSocket->IsConnected()) {
+    if (s2sSocket != nullptr && s2sSocket->IsConnected()) {
         disconnect();
     }
     deregisterRTTCallback();
-}
-
-void US2SRTTComms::request(const FString& requestJson, const US2SCallback& Callback)
-{
-    if (m_s2sClient.IsValid()) {
-        m_s2sClient->request(requestJson, Callback);
-    }
-}
-
-void US2SRTTComms::authenticate(const US2SCallback& callback)
-{
-    if (m_s2sClient.IsValid()) {
-        m_s2sClient->authenticate(callback);
-    }
-}
-
-void US2SRTTComms::authenticate()
-{
-    if (m_s2sClient.IsValid()) {
-        m_s2sClient->authenticate();
-    }
 }
 
 FString US2SRTTComms::getUrlQueryParameters()
@@ -226,7 +194,7 @@ void US2SRTTComms::joinSystemChatChannel(const US2SCallback& callback)
 
 void US2SRTTComms::disconnect()
 {
-    if (!m_s2sClient.IsValid()) return;
+    if (m_s2sClient == nullptr) return;
     if (s2sSocket == nullptr) return;
     if (!s2sSocket->IsConnected()) return;
 
@@ -252,11 +220,12 @@ void US2SRTTComms::disconnect()
     m_heartBeatSent = false;
     m_heartBeatRecv = true;
     m_timeSinceLastRequest = 0;
+    isRTTEnabled = false;
 }
 
 void US2SRTTComms::webSocket_OnMessage(const TArray<uint8>& in_data)
 {
-    FString parsedMessage = ConvertUtilities::BCBytesToString(in_data);
+    FString parsedMessage = ConvertUtilities::BCBytesToString(in_data.GetData(), in_data.Num());
     UE_LOG(S2SWebSocket, Log, TEXT("RECV: %s "), *parsedMessage);
 
     TSharedPtr<FJsonObject> jsonData = JsonUtil::jsonStringToValue(parsedMessage);
@@ -316,7 +285,7 @@ void US2SRTTComms::webSocket_OnMessage(const TArray<uint8>& in_data)
 
 void US2SRTTComms::webSocket_OnError(const FString& in_error)
 {
-    if (m_s2sClient.IsValid())
+    if (m_s2sClient != nullptr)
         UE_LOG(S2SWebSocket, Log, TEXT("Error: %s"), *in_error);
 
     rttEnabledFailureCallback(in_error);
@@ -324,7 +293,7 @@ void US2SRTTComms::webSocket_OnError(const FString& in_error)
 
 void US2SRTTComms::webSocket_OnClose()
 {
-    if (m_s2sClient.IsValid())
+    if (m_s2sClient != nullptr)
     {
         UE_LOG(S2SWebSocket, Log, TEXT("Connection closed"));
 
@@ -351,12 +320,15 @@ FString US2SRTTComms::buildConnectionRequest()
 {
     FString platform = UGameplayStatics::GetPlatformName();
 
+    // Get appId from the owning S2S context
+    FString appId = m_s2sClient ? m_s2sClient->getSessionData().appId : TEXT("");
+
     TSharedRef<FJsonObject> sysJson = MakeShareable(new FJsonObject());
     sysJson->SetStringField("platform", platform);
     sysJson->SetStringField("protocol", "ws");
 
     TSharedRef<FJsonObject> jsonData = MakeShareable(new FJsonObject());
-    jsonData->SetStringField("appId", m_appId);
+    jsonData->SetStringField("appId", appId);
     jsonData->SetStringField("sessionId", m_s2sClient->getSessionID());
     jsonData->SetStringField("profileId", "s");
     jsonData->SetObjectField("system", sysJson);
@@ -404,4 +376,59 @@ void US2SRTTComms::processRTTCallback(const FString& in_message)
 {
     if (registeredBPCallback != nullptr)
         registeredBPCallback(in_message);
+}
+
+// --------------------------------------------------------------------------
+// Blueprint wrapper helper
+// --------------------------------------------------------------------------
+
+US2SCallback US2SRTTComms::WrapBPDelegate(const FS2SResponseDelegate& Delegate)
+{
+    FS2SResponseDelegate DelegateCopy = Delegate;
+    return [DelegateCopy](const FString& JsonResponse)
+    {
+        // For RTT messages, determine success from the status field if present
+        bool bSuccess = true;
+        TSharedRef<TJsonReader<TCHAR>> Reader = TJsonReaderFactory<TCHAR>::Create(JsonResponse);
+        TSharedPtr<FJsonObject> JsonObj;
+        if (FJsonSerializer::Deserialize(Reader, JsonObj) && JsonObj->HasField(TEXT("status")))
+        {
+            bSuccess = (JsonObj->GetIntegerField(TEXT("status")) == 200);
+        }
+        DelegateCopy.ExecuteIfBound(bSuccess, JsonResponse);
+    };
+}
+
+// --------------------------------------------------------------------------
+// Blueprint wrappers
+// --------------------------------------------------------------------------
+
+void US2SRTTComms::S2S_EnableRTT(const FS2SResponseDelegate& OnSuccess, const FS2SResponseDelegate& OnFailure)
+{
+    enableRTT(WrapBPDelegate(OnSuccess), WrapBPDelegate(OnFailure));
+}
+
+void US2SRTTComms::S2S_DisableRTT()
+{
+    disableRTT();
+}
+
+void US2SRTTComms::S2S_RegisterRTTCallback(const FS2SResponseDelegate& Callback)
+{
+    registerRTTCallback(WrapBPDelegate(Callback));
+}
+
+void US2SRTTComms::S2S_DeregisterRTTCallback()
+{
+    deregisterRTTCallback();
+}
+
+void US2SRTTComms::S2S_Send(const FString& Message, bool bAllowLogging)
+{
+    send(Message, bAllowLogging);
+}
+
+void US2SRTTComms::S2S_Disconnect()
+{
+    disconnect();
 }

--- a/Source/BrainCloudS2SPlugin/Private/S2SRequestBuilder.h
+++ b/Source/BrainCloudS2SPlugin/Private/S2SRequestBuilder.h
@@ -1,0 +1,48 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+
+/**
+ * Lightweight helpers for building the inner S2S message JSON:
+ *
+ *   {"service":"<svc>","operation":"<op>"}
+ *   {"service":"<svc>","operation":"<op>","data":{...}}
+ *
+ * Use S2SServiceName / S2SServiceOperation / S2SOperationParam constants
+ * together with these functions to avoid raw string literals.
+ */
+namespace S2SRequestBuilder
+{
+    /** Build a message with no data object. */
+    inline FString Build(const TCHAR* Service, const TCHAR* Operation)
+    {
+        TSharedRef<FJsonObject> Request = MakeShared<FJsonObject>();
+        Request->SetStringField(TEXT("service"),   Service);
+        Request->SetStringField(TEXT("operation"), Operation);
+
+        FString Output;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Output);
+        FJsonSerializer::Serialize(Request, Writer);
+        return Output;
+    }
+
+    /** Build a message with a pre-populated data object. */
+    inline FString Build(const TCHAR* Service, const TCHAR* Operation,
+                         const TSharedRef<FJsonObject>& Data)
+    {
+        TSharedRef<FJsonObject> Request = MakeShared<FJsonObject>();
+        Request->SetStringField(TEXT("service"),   Service);
+        Request->SetStringField(TEXT("operation"), Operation);
+        Request->SetObjectField(TEXT("data"),      Data);
+
+        FString Output;
+        TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Output);
+        FJsonSerializer::Serialize(Request, Writer);
+        return Output;
+    }
+}

--- a/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
+++ b/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
@@ -101,6 +101,13 @@ public:
     void setLogEnabled(bool enabled);
 
     /*
+     * Set whether sensitive fields (e.g. serverSecret) are obfuscated in logs.
+     * Obfuscation is enabled by default. Disable only for local debugging.
+     * @param enabled Will obfuscate if true. Default true
+     */
+    void setLogObfuscationEnabled(bool enabled);
+
+    /*
      * Send an S2S request.
      * @param json Content to be sent
      * @param callback Callback function
@@ -158,6 +165,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Set Log Enabled"))
     void S2S_SetLogEnabled(bool bEnabled);
 
+    /** Enables or disables obfuscation of sensitive fields (e.g. serverSecret) in logs. On by default. */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Set Log Obfuscation Enabled"))
+    void S2S_SetLogObfuscationEnabled(bool bEnabled);
+
     UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Request"))
     void S2S_Request(const FString& JsonString, const FS2SResponseDelegate& Callback);
 
@@ -192,10 +203,14 @@ private:
     /** Creates and initializes owned service sub-objects. Called after Init(). */
     void InitServices();
 
+    /** Replaces the value of sensitive JSON fields (e.g. serverSecret) with "***". */
+    static FString RedactSensitiveJson(const FString& Json);
+
     TSharedPtr<Request> _activeRequest;
     TSharedPtr<Request> _nullActiveRequest;
     bool _autoAuth = false;
     bool _logEnabled = false;
+    bool _logObfuscationEnabled = true;
 
     US2SSessionData _sessionData;
 

--- a/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
+++ b/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
@@ -164,9 +164,6 @@ public:
     UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Authenticate"))
     void S2S_Authenticate(const FS2SResponseDelegate& Callback);
 
-    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Authenticate Auto"))
-    void S2S_AuthenticateAuto();
-
     UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Disconnect"))
     void S2S_Disconnect();
 

--- a/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
+++ b/Source/BrainCloudS2SPlugin/Public/BrainCloudS2S.h
@@ -4,16 +4,21 @@
 
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
+#include "BrainCloudS2STypes.h"
 
 #include <functional>
 #include <memory>
 #include <string>
 
+#include "BrainCloudS2S.generated.h"
+
 /**
- * 
+ *
  */
 
 class IHttpRequest;
+class US2SGlobalFileV3;
+class US2SRTTComms;
 
 using US2SCallback = std::function<void(const FString&)>;
 
@@ -37,21 +42,42 @@ struct US2SSessionData
 };
 
 
-
-class BRAINCLOUDS2SPLUGIN_API UBrainCloudS2S
+UCLASS(BlueprintType)
+class BRAINCLOUDS2SPLUGIN_API UBrainCloudS2S : public UObject
 {
+    GENERATED_BODY()
+
 public:
 	UBrainCloudS2S();
 
-    //Alternate constructor for those using MakeShareable
-    UBrainCloudS2S(const FString& appId,
-        const FString& serverName,
-        const FString& serverSecret,
-        const FString& url,
-        bool autoAuth
-    );
-
 	virtual ~UBrainCloudS2S();
+
+    // -----------------------------------------------------------------------
+    // Factory
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates and initializes a new S2S context. This is the recommended way
+     * to create an instance from both C++ and Blueprints.
+     *
+     * @param AppId          Application ID
+     * @param ServerName     Server name
+     * @param ServerSecret   Server secret key
+     * @param Url            The server url to send the request to.
+     * @param bAutoAuth      When true, authentication happens automatically on the first request.
+     * @return A fully initialized UBrainCloudS2S instance.
+     */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Create S2S Context"))
+    static UBrainCloudS2S* CreateS2SContext(
+        const FString& AppId,
+        const FString& ServerName,
+        const FString& ServerSecret,
+        const FString& Url,
+        bool bAutoAuth);
+
+    // -----------------------------------------------------------------------
+    // Original C++ API (signatures preserved)
+    // -----------------------------------------------------------------------
 
     /*
      * INIT - used to initialize s2s app settings if needed.
@@ -109,6 +135,44 @@ public:
 
     US2SSessionData getSessionData();
 
+    // -----------------------------------------------------------------------
+    // Service accessors
+    // -----------------------------------------------------------------------
+
+    /** Returns the Global File V3 service owned by this context. */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Get Global File V3"))
+    US2SGlobalFileV3* GetGlobalFileV3() const;
+
+    /** Returns the RTT communications service owned by this context. */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Get RTT Comms"))
+    US2SRTTComms* GetRTTComms() const;
+
+    // -----------------------------------------------------------------------
+    // Blueprint-callable wrappers
+    // -----------------------------------------------------------------------
+
+    /** Blueprint-callable version of runCallbacks(). Drives all service callbacks and HTTP completions. */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Run Callbacks"))
+    void RunCallbacks();
+
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Set Log Enabled"))
+    void S2S_SetLogEnabled(bool bEnabled);
+
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Request"))
+    void S2S_Request(const FString& JsonString, const FS2SResponseDelegate& Callback);
+
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Authenticate"))
+    void S2S_Authenticate(const FS2SResponseDelegate& Callback);
+
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Authenticate Auto"))
+    void S2S_AuthenticateAuto();
+
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S", meta = (DisplayName = "Disconnect"))
+    void S2S_Disconnect();
+
+    UFUNCTION(BlueprintCallable, BlueprintPure, Category = "BrainCloud|S2S", meta = (DisplayName = "Get Session ID"))
+    FString S2S_GetSessionID() const;
+
 private:
     struct Request
     {
@@ -125,6 +189,12 @@ private:
 
     void CheckAuthCredentials(TSharedPtr<FJsonObject> authResponse);
 
+    /** Helper: wraps an FS2SResponseDelegate into a US2SCallback. */
+    static US2SCallback WrapBPDelegate(const FS2SResponseDelegate& Delegate);
+
+    /** Creates and initializes owned service sub-objects. Called after Init(). */
+    void InitServices();
+
     TSharedPtr<Request> _activeRequest;
     TSharedPtr<Request> _nullActiveRequest;
     bool _autoAuth = false;
@@ -133,5 +203,11 @@ private:
     US2SSessionData _sessionData;
 
     TArray<TSharedPtr<Request>> _requestQueue;
-};
 
+    // Owned service instances
+    UPROPERTY()
+    US2SGlobalFileV3* _globalFileV3 = nullptr;
+
+    UPROPERTY()
+    US2SRTTComms* _rttComms = nullptr;
+};

--- a/Source/BrainCloudS2SPlugin/Public/BrainCloudS2SSubsystem.h
+++ b/Source/BrainCloudS2SPlugin/Public/BrainCloudS2SSubsystem.h
@@ -1,0 +1,64 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Tickable.h"
+
+#include "BrainCloudS2SSubsystem.generated.h"
+
+class UBrainCloudS2S;
+
+/**
+ * Game-instance subsystem that owns a UBrainCloudS2S context and ticks it
+ * automatically every frame. This is the recommended entry point for
+ * Blueprint-only projects.
+ *
+ * Usage from Blueprints:
+ *   1. Get the subsystem via "Get BrainCloud S2S Subsystem" from your GameInstance.
+ *   2. Call InitializeS2S(...) to create the context.
+ *   3. Use GetS2SContext() to access services (GlobalFileV3, RTTComms, etc.)
+ *   4. Callbacks are driven automatically — no need to call RunCallbacks().
+ */
+UCLASS()
+class BRAINCLOUDS2SPLUGIN_API UBrainCloudS2SSubsystem : public UGameInstanceSubsystem, public FTickableGameObject
+{
+    GENERATED_BODY()
+
+public:
+
+    // USubsystem interface
+    virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+    virtual void Deinitialize() override;
+
+    // FTickableGameObject interface
+    virtual void Tick(float DeltaTime) override;
+    virtual TStatId GetStatId() const override;
+    virtual bool IsTickable() const override;
+    virtual bool IsTickableInEditor() const override { return false; }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates and stores the S2S context. Call this once at startup.
+     * Subsequent calls will re-initialize the context.
+     */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|Subsystem", meta = (DisplayName = "Initialize S2S"))
+    void InitializeS2S(
+        const FString& AppId,
+        const FString& ServerName,
+        const FString& ServerSecret,
+        const FString& Url,
+        bool bAutoAuth);
+
+    /** Returns the owned S2S context, or nullptr if not yet initialized. */
+    UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|Subsystem", meta = (DisplayName = "Get S2S Context"))
+    UBrainCloudS2S* GetS2SContext() const;
+
+private:
+    UPROPERTY()
+    UBrainCloudS2S* S2SContext = nullptr;
+};

--- a/Source/BrainCloudS2SPlugin/Public/BrainCloudS2STypes.h
+++ b/Source/BrainCloudS2SPlugin/Public/BrainCloudS2STypes.h
@@ -1,0 +1,21 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BrainCloudS2STypes.generated.h"
+
+/**
+ * Dynamic delegate for Blueprint-compatible S2S response callbacks.
+ *
+ * @param bSuccess   true when the server returned HTTP 200 with a valid response.
+ * @param JsonResponse  The JSON response string from the server.
+ */
+DECLARE_DYNAMIC_DELEGATE_TwoParams(FS2SResponseDelegate, bool, bSuccess, const FString&, JsonResponse);
+
+/** Placeholder struct so UHT processes this header and registers the delegate. */
+USTRUCT()
+struct FS2STypes
+{
+	GENERATED_BODY()
+};

--- a/Source/BrainCloudS2SPlugin/Public/S2SGlobalFileV3.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SGlobalFileV3.h
@@ -1,0 +1,275 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BrainCloudS2STypes.h"
+
+#include <functional>
+#include <mutex>
+#include <queue>
+
+#include "S2SGlobalFileV3.generated.h"
+
+using US2SCallback = std::function<void(const FString&)>;
+
+class UBrainCloudS2S;
+
+/**
+* S2S service for brainCloud Global File V3 operations.
+*
+* Access via UBrainCloudS2S::GetGlobalFileV3() after creating a context.
+*
+* File upload is a two-step process:
+*   1. SYS_PREPARE_UPLOAD is sent via the S2S dispatcher and returns an uploadId.
+*   2. The file bytes are POSTed as multipart/form-data to the upload endpoint.
+*
+* The upload callback is dispatched on the next call to UBrainCloudS2S::runCallbacks()
+* after the upload HTTP request completes.
+*/
+
+UCLASS(BlueprintType)
+class BRAINCLOUDS2SPLUGIN_API US2SGlobalFileV3 : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	US2SGlobalFileV3();
+
+	/** Called internally to wire this service to its owning S2S context. */
+	void SetS2SContext(UBrainCloudS2S* context);
+
+	/**
+	* Derives the upload URL from the S2S dispatcher URL. Called by S2SContext automatically.
+	*/
+	void init(const FString& serverUrl);
+
+	// -----------------------------------------------------------------------
+	// File Info / Query
+	// -----------------------------------------------------------------------
+
+	/** Returns metadata for a global file identified by its fileId. */
+	void sysGetFileInfo(const FString& fileId, const US2SCallback& callback);
+
+	/** Returns metadata for a global file identified by folder path and filename. */
+	void sysGetFileInfoSimple(const FString& folderPath, const FString& filename,
+		const US2SCallback& callback);
+
+	/** Returns true if a file with the given name exists in the specified folder. */
+	void sysCheckFilenameExists(const FString& folderPath, const FString& filename,
+		const US2SCallback& callback);
+
+	/** Returns true if a file exists at the given full path (e.g. "folder/sub/file.txt"). */
+	void sysCheckFullpathFilenameExists(const FString& fullpathFilename,
+		const US2SCallback& callback);
+
+	/** Returns the CDN URL for the global file identified by fileId. */
+	void sysGetGlobalCDNUrl(const FString& fileId, const US2SCallback& callback);
+
+	/**
+	* Lists all global files under the given folder path.
+	* Pass folderPath="" and recurse=true to list the entire tree.
+	*/
+	void sysGetGlobalFileList(const FString& folderPath, bool recurse,
+		const US2SCallback& callback);
+
+	// -----------------------------------------------------------------------
+	// File Management
+	// -----------------------------------------------------------------------
+
+	/** Moves a file from personal cloud storage into the global file system. */
+	void sysMoveToGlobalFile(const FString& userProfileId, const FString& userCloudPath,
+		const FString& userCloudFilename, const FString& globalTreeId,
+		const FString& globalFilename, bool overwriteIfPresent,
+		const US2SCallback& callback);
+
+	/**
+	* Copies a global file to another folder, optionally with a new name.
+	* Pass version=-1 to copy the latest version. Pass treeVersion=-1 to skip the version check.
+	*/
+	void sysCopyGlobalFile(const FString& fileId, int version,
+		const FString& newTreeId, int treeVersion,
+		const FString& newFilename, bool overwriteIfPresent,
+		const US2SCallback& callback);
+
+	/**
+	* Moves a global file to another folder, optionally with a new name.
+	* Pass version=-1 to move the latest version. Pass treeVersion=-1 to skip the version check.
+	*/
+	void sysMoveGlobalFile(const FString& fileId, int version,
+		const FString& newTreeId, int treeVersion,
+		const FString& newFilename, bool overwriteIfPresent,
+		const US2SCallback& callback);
+
+	/** Deletes a single global file. Pass version=-1 to delete without a version check. */
+	void sysDeleteGlobalFile(const FString& fileId, int version,
+		const FString& filename, const US2SCallback& callback);
+
+	/**
+	* Deletes all global files in the specified folder.
+	* Pass treeVersion=-1 to skip the version check. Set recurse=true to include sub-folders.
+	*/
+	void sysDeleteGlobalFiles(const FString& treeId, const FString& folderPath,
+		int treeVersion, bool recurse, const US2SCallback& callback);
+
+	// -----------------------------------------------------------------------
+	// Folder Management
+	// -----------------------------------------------------------------------
+
+	/**
+	* Creates a new folder at the given path.
+	* Pass treeVersion=-1 to skip the version check.
+	* Set createInterimDirectories=true to auto-create any missing parent folders.
+	*/
+	void sysCreateFolder(const FString& folderPath, int treeVersion,
+		const FString& name, const FString& desc,
+		bool createInterimDirectories, const US2SCallback& callback);
+
+	/**
+	 * Moves a folder to a new path, optionally renaming it.
+	 * Pass treeVersion=-1 to skip the version check.
+	 */
+	void sysMoveFolder(const FString& treeId, int treeVersion,
+		const FString& newFolderPath, const FString& updatedName,
+		bool createInterimDirectories, const US2SCallback& callback);
+
+	/**
+	 * Renames a folder in place.
+	 * Pass treeVersion=-1 to skip the version check.
+	 */
+	void sysRenameFolder(const FString& treeId, int treeVersion,
+		const FString& updatedName, const US2SCallback& callback);
+
+	/** Resolves the treeId for a folder given its full path. */
+	void sysLookupFolder(const FString& fullFolderPath, const US2SCallback& callback);
+
+	/**
+	 * Deletes a folder. Set force=true to also delete any files and sub-folders inside it.
+	 * Pass treeVersion=-1 to skip the version check.
+	 */
+	void sysDeleteFolder(const FString& treeId, const FString& folderPath,
+		int treeVersion, bool force, const US2SCallback& callback);
+
+	// -----------------------------------------------------------------------
+	// Upload
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Uploads a file to the brainCloud Global File V3 system via S2S.
+	 *
+	 * NOTE: Not exposed to Blueprints because fileData is a std::vector<uint8_t>,
+	 * which is not a Blueprint-compatible type.
+	 *
+	 * @param treeId              Folder tree ID (use "_root_" for root)
+	 * @param filename            Name of the file as it will appear in brainCloud
+	 * @param overwriteIfPresent  Replaces any existing file with the same name when true
+	 * @param fileData            File content as bytes
+	 * @param callback            Invoked with the upload result JSON string
+	 */
+	void uploadGlobalFile(const FString& treeId, const FString& filename,
+		bool overwriteIfPresent, const std::vector<uint8_t>& fileData,
+		const US2SCallback& callback);
+
+	// -----------------------------------------------------------------------
+	// Lifecycle (called internally by S2SContext)
+	// -----------------------------------------------------------------------
+
+	/** Dispatches completed upload callbacks. Called by S2SContext::runCallbacks(). */
+	void runCallbacks();
+
+	/** Cancels pending upload callbacks. Called by S2SContext::disconnect(). */
+	void disconnect();
+
+	// -----------------------------------------------------------------------
+	// Blueprint wrappers (S2S_ prefix)
+	// -----------------------------------------------------------------------
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Get File Info"))
+	void S2S_SysGetFileInfo(const FString& FileId, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Get File Info Simple"))
+	void S2S_SysGetFileInfoSimple(const FString& FolderPath, const FString& Filename, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Check Filename Exists"))
+	void S2S_SysCheckFilenameExists(const FString& FolderPath, const FString& Filename, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Check Fullpath Filename Exists"))
+	void S2S_SysCheckFullpathFilenameExists(const FString& FullpathFilename, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Get Global CDN Url"))
+	void S2S_SysGetGlobalCDNUrl(const FString& FileId, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Get Global File List"))
+	void S2S_SysGetGlobalFileList(const FString& FolderPath, bool bRecurse, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Move To Global File"))
+	void S2S_SysMoveToGlobalFile(const FString& UserProfileId, const FString& UserCloudPath,
+		const FString& UserCloudFilename, const FString& GlobalTreeId,
+		const FString& GlobalFilename, bool bOverwriteIfPresent,
+		const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Copy Global File"))
+	void S2S_SysCopyGlobalFile(const FString& FileId, int32 Version,
+		const FString& NewTreeId, int32 TreeVersion,
+		const FString& NewFilename, bool bOverwriteIfPresent,
+		const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Move Global File"))
+	void S2S_SysMoveGlobalFile(const FString& FileId, int32 Version,
+		const FString& NewTreeId, int32 TreeVersion,
+		const FString& NewFilename, bool bOverwriteIfPresent,
+		const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Delete Global File"))
+	void S2S_SysDeleteGlobalFile(const FString& FileId, int32 Version,
+		const FString& Filename, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Delete Global Files"))
+	void S2S_SysDeleteGlobalFiles(const FString& TreeId, const FString& FolderPath,
+		int32 TreeVersion, bool bRecurse, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Create Folder"))
+	void S2S_SysCreateFolder(const FString& FolderPath, int32 TreeVersion,
+		const FString& Name, const FString& Desc,
+		bool bCreateInterimDirectories, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Move Folder"))
+	void S2S_SysMoveFolder(const FString& TreeId, int32 TreeVersion,
+		const FString& NewFolderPath, const FString& UpdatedName,
+		bool bCreateInterimDirectories, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Rename Folder"))
+	void S2S_SysRenameFolder(const FString& TreeId, int32 TreeVersion,
+		const FString& UpdatedName, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Lookup Folder"))
+	void S2S_SysLookupFolder(const FString& FullFolderPath, const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|GlobalFileV3", meta = (DisplayName = "Sys Delete Folder"))
+	void S2S_SysDeleteFolder(const FString& TreeId, const FString& FolderPath,
+		int32 TreeVersion, bool bForce, const FS2SResponseDelegate& Callback);
+
+private:
+	UPROPERTY()
+	UBrainCloudS2S* _s2s = nullptr;
+
+	FString _uploadUrl;
+	std::atomic<int> _generation;
+
+	struct UploadCompletion
+	{
+		US2SCallback callback;
+		FString result;
+	};
+
+	std::mutex _uploadMutex;
+	std::queue<UploadCompletion> _completedUploads;
+
+	void sendFileUpload(const FString& uploadUrl, const FString& filename,
+		const std::vector<uint8_t>& fileData, const US2SCallback& callback);
+
+	void log(const FString& message);
+
+	/** Helper: wraps an FS2SResponseDelegate into a US2SCallback. */
+	static US2SCallback WrapBPDelegate(const FS2SResponseDelegate& Delegate);
+};

--- a/Source/BrainCloudS2SPlugin/Public/S2SOperationParam.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SOperationParam.h
@@ -1,0 +1,91 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * String constants for JSON field/parameter names used in S2S request data objects.
+ */
+namespace S2SOperationParam
+{
+    // -----------------------------------------------------------------------
+    // Envelope / session
+    // -----------------------------------------------------------------------
+    static constexpr const TCHAR* PacketId         = TEXT("packetId");
+    static constexpr const TCHAR* SessionId        = TEXT("sessionId");
+    static constexpr const TCHAR* Messages         = TEXT("messages");
+    static constexpr const TCHAR* MessageResponses = TEXT("messageResponses");
+    static constexpr const TCHAR* Status           = TEXT("status");
+    static constexpr const TCHAR* ReasonCode       = TEXT("reason_code");
+
+    // -----------------------------------------------------------------------
+    // Authentication
+    // -----------------------------------------------------------------------
+    static constexpr const TCHAR* AppId        = TEXT("appId");
+    static constexpr const TCHAR* ServerName   = TEXT("serverName");
+    static constexpr const TCHAR* ServerSecret = TEXT("serverSecret");
+
+    // -----------------------------------------------------------------------
+    // RTT / WebSocket
+    // -----------------------------------------------------------------------
+    static constexpr const TCHAR* Platform          = TEXT("platform");
+    static constexpr const TCHAR* Protocol          = TEXT("protocol");
+    static constexpr const TCHAR* ProfileId         = TEXT("profileId");
+    static constexpr const TCHAR* System            = TEXT("system");
+    static constexpr const TCHAR* Auth              = TEXT("auth");
+    static constexpr const TCHAR* Endpoints        = TEXT("endpoints");
+    static constexpr const TCHAR* Ssl               = TEXT("ssl");
+    static constexpr const TCHAR* Host              = TEXT("host");
+    static constexpr const TCHAR* Port              = TEXT("port");
+    static constexpr const TCHAR* CxId              = TEXT("cxId");
+    static constexpr const TCHAR* Evs               = TEXT("evs");
+    static constexpr const TCHAR* HeartbeatSeconds  = TEXT("heartbeatSeconds");
+    static constexpr const TCHAR* WsHeartbeatSecs   = TEXT("wsHeartbeatSecs");
+    static constexpr const TCHAR* Reason            = TEXT("reason");
+    static constexpr const TCHAR* Severity          = TEXT("severity");
+
+    // -----------------------------------------------------------------------
+    // globalFileV3 — common
+    // -----------------------------------------------------------------------
+    static constexpr const TCHAR* FileId              = TEXT("fileId");
+    static constexpr const TCHAR* FolderPath          = TEXT("folderPath");
+    static constexpr const TCHAR* Filename            = TEXT("filename");
+    static constexpr const TCHAR* FullPathFilename    = TEXT("fullPathFilename");
+    static constexpr const TCHAR* Recurse             = TEXT("recurse");
+    static constexpr const TCHAR* OverwriteIfPresent  = TEXT("overwriteIfPresent");
+    static constexpr const TCHAR* Version             = TEXT("version");
+    static constexpr const TCHAR* TreeId              = TEXT("treeId");
+    static constexpr const TCHAR* TreeVersion         = TEXT("treeVersion");
+    static constexpr const TCHAR* NewTreeId           = TEXT("newTreeId");
+    static constexpr const TCHAR* NewFilename         = TEXT("newFilename");
+    static constexpr const TCHAR* FileSize            = TEXT("fileSize");
+    static constexpr const TCHAR* FileDetails         = TEXT("fileDetails");
+    static constexpr const TCHAR* UploadId            = TEXT("uploadId");
+    static constexpr const TCHAR* UploadUrl           = TEXT("uploadUrl");
+
+    // globalFileV3 — user file move
+    static constexpr const TCHAR* UserProfileId    = TEXT("userProfileId");
+    static constexpr const TCHAR* UserCloudPath    = TEXT("userCloudPath");
+    static constexpr const TCHAR* UserCloudFilename = TEXT("userCloudFilename");
+    static constexpr const TCHAR* GlobalTreeId     = TEXT("globalTreeId");
+    static constexpr const TCHAR* GlobalFilename   = TEXT("globalFilename");
+
+    // globalFileV3 — folder management
+    static constexpr const TCHAR* Name                     = TEXT("name");
+    static constexpr const TCHAR* Desc                     = TEXT("desc");
+    static constexpr const TCHAR* CreateInterimDirectories = TEXT("createInterimDirectories");
+    static constexpr const TCHAR* NewFolderPath            = TEXT("newFolderPath");
+    static constexpr const TCHAR* UpdatedName              = TEXT("updatedName");
+    static constexpr const TCHAR* FullFolderPath           = TEXT("fullFolderPath");
+    static constexpr const TCHAR* Force                    = TEXT("force");
+    static constexpr const TCHAR* CreatedTreeId            = TEXT("createdTreeId");
+
+    // -----------------------------------------------------------------------
+    // Chat
+    // -----------------------------------------------------------------------
+    static constexpr const TCHAR* ChannelId       = TEXT("channelId");
+    static constexpr const TCHAR* MaxReturn       = TEXT("maxReturn");
+    static constexpr const TCHAR* Content         = TEXT("content");
+    static constexpr const TCHAR* RecordInHistory = TEXT("recordInHistory");
+}

--- a/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SRTTComms.h
@@ -4,6 +4,7 @@
 
 #include "S2SSocket.h"
 #include "BrainCloudS2S.h"
+#include "BrainCloudS2STypes.h"
 
 #include "S2SRTTComms.generated.h"
 
@@ -29,22 +30,12 @@ public:
 	US2SRTTComms();
 	~US2SRTTComms();
 
-	/*
-	 * InitializeS2S - used to initialize s2s app settings if needed.
-	 * @param appId Application ID
-	 * @param serverName Server name
-	 * @param serverSecret Server secret key
-	 * @param url The server url to send the request to.
-	 */
-	void InitializeS2S(const FString& appId,
-		const FString& serverName,
-		const FString& serverSecret,
-		const FString& url,
-		bool autoAuth,
-		bool logEnabled);
+	/** Called internally by UBrainCloudS2S to wire this service to its owning context. */
+	void SetS2SContext(UBrainCloudS2S* context);
 
 	/*
-	 * Update and perform callbacks on the calling thread.
+	 * Update RTT heartbeats and check for disconnection.
+	 * Called by UBrainCloudS2S::runCallbacks().
 	 */
 	void runCallbacks();
 
@@ -64,24 +55,6 @@ public:
 	 * Disables RTT
 	 */
 	void disableRTT();
-
-	/*
-	 * request - makes an S2S request 
-	 * @param requestJson the json data string sent in the request
-	 * @param Callback Callback for when we get a response
-	 */
-	void request(const FString& requestJson, const US2SCallback& Callback);
-
-	/*
-	 * authenticate - authenticates and starts the S2S session
-	 * @param callback Callback for the authentication response
-	 */
-	void authenticate(const US2SCallback& callback);
-
-	/*
-	 * authenticate - authenticates and starts the S2S session
-	 */
-	void authenticate();
 
 	/*
 	 * registerRTTCallback - registers an RTT callback that is triggered when we receive an RTT message
@@ -128,24 +101,49 @@ public:
 	UFUNCTION()
 	void webSocket_OnError(const FString& in_error);
 
+	// -----------------------------------------------------------------------
+	// Blueprint wrappers (S2S_ prefix)
+	// -----------------------------------------------------------------------
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Enable RTT"))
+	void S2S_EnableRTT(const FS2SResponseDelegate& OnSuccess, const FS2SResponseDelegate& OnFailure);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Disable RTT"))
+	void S2S_DisableRTT();
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Register RTT Callback"))
+	void S2S_RegisterRTTCallback(const FS2SResponseDelegate& Callback);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Deregister RTT Callback"))
+	void S2S_DeregisterRTTCallback();
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Send RTT Message"))
+	void S2S_Send(const FString& Message, bool bAllowLogging = true);
+
+	UFUNCTION(BlueprintCallable, Category = "BrainCloud|S2S|RTT", meta = (DisplayName = "Disconnect RTT"))
+	void S2S_Disconnect();
+
 private:
 
 	FString getUrlQueryParameters();
 	void setupWebSocket(const FString& in_url);
 	void setRTTHeartBeatSeconds(int32 in_value);
-	
+
 	FString buildConnectionRequest();
 	FString buildHeartbeatRequest();
 
 	void processRTTCallback(const FString &in_message);
 
-	US2SSocket *s2sSocket;
+	/** Helper: wraps an FS2SResponseDelegate into a US2SCallback (success is always true for RTT messages). */
+	static US2SCallback WrapBPDelegate(const FS2SResponseDelegate& Delegate);
+
+	US2SSocket *s2sSocket = nullptr;
 
 	FString m_cxId;
 	FString m_eventServer;
-	FString m_appId;
 
-	TSharedPtr<UBrainCloudS2S> m_s2sClient;
+	UPROPERTY()
+	UBrainCloudS2S* m_s2sClient = nullptr;
 	TSharedPtr<FJsonObject> m_rttHeaders;
 	TSharedRef<FJsonObject> m_disconnectJson = MakeShareable(new FJsonObject());
 
@@ -165,7 +163,3 @@ private:
 	US2SCallback rttEnabledSuccessCallback;
 	US2SCallback rttEnabledFailureCallback;
 };
-
-
-
-

--- a/Source/BrainCloudS2SPlugin/Public/S2SServiceName.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SServiceName.h
@@ -1,0 +1,25 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * String constants for all S2S service names.
+ * Use these instead of raw string literals when calling request() or
+ * building JSON manually.
+ */
+namespace S2SServiceName
+{
+    // Core
+    static constexpr const TCHAR* AuthenticationV2 = TEXT("authenticationV2");
+    static constexpr const TCHAR* Heartbeat        = TEXT("heartbeat");
+
+    // Real-Time Tech (RTT)
+    static constexpr const TCHAR* RTTRegistration = TEXT("rttRegistration");
+    static constexpr const TCHAR* RTT             = TEXT("RTT");
+
+    // Services
+    static constexpr const TCHAR* GlobalFileV3 = TEXT("globalFileV3");
+    static constexpr const TCHAR* Chat         = TEXT("chat");
+}

--- a/Source/BrainCloudS2SPlugin/Public/S2SServiceOperation.h
+++ b/Source/BrainCloudS2SPlugin/Public/S2SServiceOperation.h
@@ -1,0 +1,52 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * String constants for all S2S operation names.
+ * Grouped by the service they belong to.
+ */
+namespace S2SServiceOperation
+{
+    // authenticationV2
+    static constexpr const TCHAR* Authenticate = TEXT("AUTHENTICATE");
+
+    // heartbeat  /  RTT (both use the same wire string)
+    static constexpr const TCHAR* Heartbeat = TEXT("HEARTBEAT");
+
+    // rttRegistration
+    static constexpr const TCHAR* RequestSystemConnection = TEXT("REQUEST_SYSTEM_CONNECTION");
+
+    // RTT (websocket layer)
+    static constexpr const TCHAR* Connect    = TEXT("CONNECT");
+    static constexpr const TCHAR* Disconnect = TEXT("DISCONNECT");
+
+    // globalFileV3 — file info / query
+    static constexpr const TCHAR* SysGetFileInfo                  = TEXT("SYS_GET_FILE_INFO");
+    static constexpr const TCHAR* SysGetFileInfoSimple            = TEXT("SYS_GET_FILE_INFO_SIMPLE");
+    static constexpr const TCHAR* SysCheckFilenameExists          = TEXT("SYS_CHECK_FILENAME_EXISTS");
+    static constexpr const TCHAR* SysCheckFullpathFilenameExists  = TEXT("SYS_CHECK_FULLPATH_FILENAME_EXISTS");
+    static constexpr const TCHAR* SysGetGlobalCDNUrl              = TEXT("SYS_GET_GLOBAL_CDN_URL");
+    static constexpr const TCHAR* SysGetGlobalFileList            = TEXT("SYS_GET_GLOBAL_FILE_LIST");
+
+    // globalFileV3 — file management
+    static constexpr const TCHAR* SysMoveToGlobalFile = TEXT("SYS_MOVE_TO_GLOBAL_FILE");
+    static constexpr const TCHAR* SysCopyGlobalFile   = TEXT("SYS_COPY_GLOBAL_FILE");
+    static constexpr const TCHAR* SysMoveGlobalFile   = TEXT("SYS_MOVE_GLOBAL_FILE");
+    static constexpr const TCHAR* SysDeleteGlobalFile  = TEXT("SYS_DELETE_GLOBAL_FILE");
+    static constexpr const TCHAR* SysDeleteGlobalFiles = TEXT("SYS_DELETE_GLOBAL_FILES");
+    static constexpr const TCHAR* SysPrepareUpload     = TEXT("SYS_PREPARE_UPLOAD");
+
+    // globalFileV3 — folder management
+    static constexpr const TCHAR* SysCreateFolder = TEXT("SYS_CREATE_FOLDER");
+    static constexpr const TCHAR* SysMoveFolder   = TEXT("SYS_MOVE_FOLDER");
+    static constexpr const TCHAR* SysRenameFolder = TEXT("SYS_RENAME_FOLDER");
+    static constexpr const TCHAR* SysLookupFolder = TEXT("SYS_LOOKUP_FOLDER");
+    static constexpr const TCHAR* SysDeleteFolder = TEXT("SYS_DELETE_FOLDER");
+
+    // chat
+    static constexpr const TCHAR* SysChannelConnect  = TEXT("SYS_CHANNEL_CONNECT");
+    static constexpr const TCHAR* SysPostChatMessage = TEXT("SYS_POST_CHAT_MESSAGE");
+}


### PR DESCRIPTION
Refactored S2S to improve the structure and memory management of this library.

BrainCloudS2S class is now the main context where every other service (including RTT) is accessible. 
BrainCloudS2S is now also a UObject so that it's lifetime is completely managed by Unreal and its garbage collection

Now obfuscating secrets from the logs
Added GlobalFileV3 service for file upload
All public facing functions are now available via Blueprints as well. 
Also created a subsystem for S2S which makes it even easier to use as a base for the server subsystem. (Will add example of that later on)

This is now how we can initialize a S2S Context in Blueprints:
<img width="1077" height="274" alt="image" src="https://github.com/user-attachments/assets/8fe1fc65-8791-415d-9c82-3150701bb725" />

Authentication:
<img width="535" height="346" alt="image" src="https://github.com/user-attachments/assets/704cf55a-f5a4-46b7-9aa1-576deee95ecf" />

Making S2S Requests:
<img width="662" height="369" alt="image" src="https://github.com/user-attachments/assets/7437dd35-ecb6-4d5e-a12f-2c2f35e49158" />

Enabling RTT:
<img width="617" height="500" alt="image" src="https://github.com/user-attachments/assets/7875bee8-a227-437c-aa3a-b4b10d78f52b" />

(And more...)


Test results from all tests:

[TestLogs_2026_03_04.txt](https://github.com/user-attachments/files/25750163/TestLogs_2026_03_04.txt)
